### PR TITLE
Fix cherry blossom petals causing horizontal page overflow

### DIFF
--- a/personal-website/src/lib/components/site/Garden.svelte
+++ b/personal-website/src/lib/components/site/Garden.svelte
@@ -315,6 +315,7 @@
 		for (const p of petals) {
 			p.phase += (0.035 + p.size * 0.02) * dt;
 			p.x += (p.vx + Math.sin(p.phase) * p.phaseAmp) * dt;
+			p.x = clamp(p.x, 4, Math.max(4, w - 4));
 			p.y += p.vy * dt;
 			p.rot += p.rotVel * dt;
 			p.life += dt;


### PR DESCRIPTION
## Summary
- Cherry blossom petals in `Garden.svelte` drifted horizontally with no bound, pushing them well past the viewport edge on narrow screens (e.g. `scrollWidth` 645px vs `clientWidth` 375px at a 375px mobile width) and causing the whole page to scroll horizontally.
- Clamped petal `x` position to the garden container's width each frame instead of loosening `overflow` on the `.garden` wrapper, since that wrapper is intentionally `overflow: visible` for the watering can's vertical throw arc and the swaying tree crowns.

## Why
Petals spawn near the cherry tree's foliage (close to the right edge) and accumulate drift via `vx` plus an unbounded `sin(phase) * phaseAmp` oscillation over their ~5-9s lifetime — enough to reach ~150px+ past the spawn point, which on mobile exceeds the viewport.

## Test plan
- [x] Reproduced the bug analytically: replicated the exact petal update math in a standalone script across 20,000 randomized lifetimes at 375px container width — without the fix, max x reached ~535px (matching the reported order of magnitude); with the fix, max x never exceeded 371px.
- [ ] Manual check in a real browser at a 375px viewport: load the site, scroll to the footer garden, watch petals for ~30s, confirm `document.documentElement.scrollWidth === document.documentElement.clientWidth`. (Not verified live — this sandbox's browser tab reports as backgrounded/hidden, which pauses `requestAnimationFrame` entirely, so petals never animated during my session.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
