### PR TITLE
Polish homepage: contact section, book shelf redesign, mobile nav

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "personal-website",
+			"runtimeExecutable": "pnpm",
+			"runtimeArgs": ["dev"],
+			"port": 5173
+		}
+	]
+}

--- a/personal-website/src/lib/components/site/BlockHead.svelte
+++ b/personal-website/src/lib/components/site/BlockHead.svelte
@@ -30,7 +30,7 @@
 	.block-head h2 {
 		font-family: var(--font-heading);
 		font-size: 1.2rem;
-		font-weight: 600;
+		font-weight: 700;
 		letter-spacing: 0.04em;
 		text-transform: uppercase;
 		color: var(--color-heading);

--- a/personal-website/src/lib/components/site/BookStack.svelte
+++ b/personal-website/src/lib/components/site/BookStack.svelte
@@ -63,8 +63,7 @@
 	.shelf {
 		display: grid;
 		grid-template-columns: repeat(var(--count), minmax(0, 1fr));
-		grid-template-rows: auto auto;
-		grid-auto-flow: column;
+		grid-auto-rows: auto;
 		column-gap: clamp(0.85rem, 2vw, 1.5rem);
 		row-gap: 0.85rem;
 		list-style: none;
@@ -73,7 +72,10 @@
 	}
 
 	.slot {
-		display: contents;
+		display: grid;
+		grid-row: span 2;
+		grid-template-rows: subgrid;
+		min-width: 0;
 	}
 
 	.book {
@@ -87,8 +89,7 @@
 		display: block;
 		aspect-ratio: 2 / 3;
 		border-radius: 3px 5px 5px 3px;
-		filter: drop-shadow(0 8px 14px rgb(36 37 37 / 0.16))
-			drop-shadow(0 2px 4px rgb(36 37 37 / 0.1));
+		filter: drop-shadow(0 8px 14px rgb(36 37 37 / 0.16)) drop-shadow(0 2px 4px rgb(36 37 37 / 0.1));
 		transition:
 			transform var(--duration-base) cubic-bezier(0.2, 0.8, 0.2, 1),
 			filter var(--duration-base) ease;
@@ -151,19 +152,30 @@
 		outline-offset: 4px;
 	}
 
-	@media (max-width: 820px) {
+	// Column counts that divide the shelf evenly, so a wrapped row is never left
+	// with a single orphan cover.
+	@media (max-width: 760px) {
 		.shelf {
-			grid-template-columns: repeat(var(--count), clamp(120px, 32vw, 160px));
-			overflow-x: auto;
-			scroll-snap-type: x proximity;
-			padding-bottom: 0.5rem;
-			margin-inline: calc(-1 * clamp(1.25rem, 4vw, 1.75rem));
-			padding-inline: clamp(1.25rem, 4vw, 1.75rem);
-			scrollbar-width: thin;
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+			row-gap: 1.35rem;
+		}
+	}
+
+	@media (max-width: 560px) {
+		.shelf {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
 		}
 
-		.cover-wrap {
-			scroll-snap-align: start;
+		.meta {
+			padding-top: 0.6rem;
+		}
+
+		.title {
+			font-size: 0.85rem;
+		}
+
+		.author {
+			font-size: 0.72rem;
 		}
 	}
 

--- a/personal-website/src/lib/components/site/Header.svelte
+++ b/personal-website/src/lib/components/site/Header.svelte
@@ -176,8 +176,8 @@
 
 		.nav-links a {
 			justify-content: center;
-			padding: 0.4rem 0;
-			margin: 0.3em 0;
+			padding: 0.25rem 0;
+			margin: 0;
 			font-size: 1rem;
 			font-weight: 500;
 		}

--- a/personal-website/src/lib/components/site/TripGallery.svelte
+++ b/personal-website/src/lib/components/site/TripGallery.svelte
@@ -6,15 +6,18 @@
 		trips: readonly PhotoTrip[];
 		gap?: number;
 		maxColumnWidth?: number;
+		minColumns?: number;
 		loading?: 'lazy' | 'eager';
 	};
 
-	let { trips, gap = 15, maxColumnWidth = 250, loading = 'lazy' }: Props = $props();
+	let { trips, gap = 15, maxColumnWidth = 250, minColumns = 1, loading = 'lazy' }: Props = $props();
 
 	let galleryWidth = $state(0);
 	let dims = $state<Record<string, { w: number; h: number }>>({});
 
-	const columnCount = $derived(Math.max(1, Math.floor(galleryWidth / maxColumnWidth) || 1));
+	const columnCount = $derived(
+		Math.max(minColumns, Math.floor(galleryWidth / maxColumnWidth) || 1)
+	);
 	const columnWidth = $derived(
 		galleryWidth > 0 ? (galleryWidth - gap * (columnCount - 1)) / columnCount : maxColumnWidth
 	);
@@ -60,13 +63,16 @@
 	{#each columns as column, ci (ci)}
 		<div class="column">
 			{#each column as trip (trip.slug)}
-				<a class="trip" href={`/photography/${trip.slug}`} aria-label={`${trip.title}, ${trip.year}`}>
+				<a
+					class="trip"
+					href={`/photography/${trip.slug}`}
+					aria-label={`${trip.title}, ${trip.year}`}
+				>
 					<img
 						src={trip.coverImage}
 						alt={trip.title}
 						{loading}
-						onload={(e) =>
-							recordDimensions(trip.coverImage, e.currentTarget as HTMLImageElement)}
+						onload={(e) => recordDimensions(trip.coverImage, e.currentTarget as HTMLImageElement)}
 						onerror={handleImgError}
 					/>
 					<div class="overlay" aria-hidden="true"></div>
@@ -103,6 +109,7 @@
 		position: relative;
 		display: block;
 		width: 100%;
+		container-type: inline-size;
 		font-family: var(--font-heading, 'Poppins', Helvetica, arial);
 		color: white;
 		text-decoration: none;
@@ -165,10 +172,10 @@
 		flex-direction: column;
 		justify-content: center;
 		margin: 0.5em 0;
-		padding: 0 1em;
+		padding: 0 clamp(0.6rem, 5cqw, 1rem);
 
 		h3 {
-			font-size: 2.2em;
+			font-size: clamp(1.1rem, 13cqw, 2.2rem);
 			color: white;
 			font-weight: 600;
 			margin: 0;
@@ -178,7 +185,7 @@
 	}
 
 	.trip-subtitle {
-		font-size: 1.25em;
+		font-size: clamp(0.8rem, 7.5cqw, 1.25rem);
 		color: white;
 		margin: 0;
 		padding: 0;
@@ -194,13 +201,13 @@
 		top: 0;
 		right: 0;
 		display: flex;
-		padding: 0.3em 1.2em;
+		padding: clamp(0.2rem, 1.5cqw, 0.35rem) clamp(0.6rem, 5cqw, 1.2rem);
 	}
 
 	.trip-date {
 		color: white;
 		opacity: 0.7;
-		font-size: 1.2em;
+		font-size: clamp(0.75rem, 7cqw, 1.2rem);
 		font-weight: 700;
 		margin: 0;
 		text-align: right;

--- a/personal-website/src/lib/content/pages.ts
+++ b/personal-website/src/lib/content/pages.ts
@@ -62,6 +62,7 @@ export const homeSections: {
 	writing: HomeBlockMeta;
 	photography: HomeBlockMeta;
 	booknotes: HomeBlockMeta;
+	contact: HomeBlockMeta;
 	more: HomeBlockMeta;
 } = {
 	currently: { title: 'Right now' },
@@ -88,6 +89,12 @@ export const homeSections: {
 		asideHref: '/booknotes',
 		intro: 'key takeaways etc. from books I\'ve read — lifestyle, philosophy, tech, whatever\'s interesting.'
 	},
+	contact: {
+		title: 'Get in touch',
+		asideLabel: 'Contact me',
+		asideHref: '/contact',
+		intro: 'got a question, a project, or just want to say hi? send a note and I\'ll reply asap.'
+	},
 	more: { title: 'More' }
 };
 
@@ -106,13 +113,6 @@ export const homeMoreCards: HomeMoreCard[] = [
 		body: 'a running log of what I\'m building, reading, and thinking about this year.',
 		cta: 'See what I\'m up to',
 		href: '/2026'
-	},
-	{
-		title: 'Get in touch',
-		meta: 'Say hi',
-		body: 'got a question, a project, or just want to chat? send me a note.',
-		cta: 'Contact me',
-		href: '/contact'
 	}
 ];
 

--- a/personal-website/src/routes/+page.svelte
+++ b/personal-website/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 	import { onMount } from 'svelte';
 	import BlockHead from '$lib/components/site/BlockHead.svelte';
 	import BookStack from '$lib/components/site/BookStack.svelte';
+	import ContactForm from '$lib/components/site/ContactForm.svelte';
 	import Seo from '$lib/components/site/Seo.svelte';
 	import TripGallery from '$lib/components/site/TripGallery.svelte';
 	import Button from '$lib/components/ui/Button.svelte';
@@ -10,6 +11,7 @@
 	import {
 		articles,
 		bookNotes,
+		contactForm,
 		homeCurrently,
 		homeIntro,
 		homeMoreCards,
@@ -144,7 +146,7 @@
 	</BlockHead>
 	<p class="intro">{homeSections.photography.intro}</p>
 	<div class="gallery-fade">
-		<TripGallery trips={featuredTrips} gap={15} maxColumnWidth={220} />
+		<TripGallery trips={featuredTrips} gap={15} maxColumnWidth={220} minColumns={2} />
 	</div>
 </Section>
 
@@ -158,22 +160,43 @@
 		{/snippet}
 	</BlockHead>
 	<p class="intro">{homeSections.booknotes.intro}</p>
-	<BookStack books={featuredBooks} pool={bookPool} count={5} />
+	<div class="shelf-fade">
+		<BookStack books={featuredBooks} pool={bookPool} count={5} />
+	</div>
 </Section>
 
-<Section>
-	<BlockHead title={homeSections.more.title} />
-	<div class="more-grid">
-		{#each homeMoreCards as card}
-			<Card href={card.href} class="more-card">
-				<h3>{card.title}</h3>
-				<p>{card.body}</p>
-				<span class="card-cta">
-					{card.cta}
-					<span class="material-symbols-rounded" aria-hidden="true">arrow_forward</span>
-				</span>
-			</Card>
-		{/each}
+{#if false}
+	<Section>
+		<BlockHead title={homeSections.more.title} />
+		<div class="more-grid">
+			{#each homeMoreCards as card}
+				<Card href={card.href} class="more-card">
+					<h3>{card.title}</h3>
+					<p>{card.body}</p>
+					<span class="card-cta">
+						{card.cta}
+						<span class="material-symbols-rounded" aria-hidden="true">arrow_forward</span>
+					</span>
+				</Card>
+			{/each}
+		</div>
+	</Section>
+{/if}
+
+<Section id="contact">
+	<BlockHead title={homeSections.contact.title}>
+		{#snippet aside()}
+			<a class="aside-link" href={homeSections.contact.asideHref}>
+				<span class="label">{homeSections.contact.asideLabel}</span>
+				<span class="material-symbols-rounded" aria-hidden="true">arrow_forward</span>
+			</a>
+		{/snippet}
+	</BlockHead>
+	<div class="contact-grid">
+		<div class="contact-details">
+			<p>{homeSections.contact.intro}</p>
+		</div>
+		<ContactForm definition={contactForm} />
 	</div>
 </Section>
 
@@ -294,14 +317,16 @@
 
 	.about p {
 		color: var(--color-subtle);
+		font-size: clamp(1rem, 1.3vw, 1.1rem);
+		line-height: 1.65;
 	}
 
 	.intro {
 		max-width: 620px;
 		margin-bottom: 2.25rem;
 		color: var(--color-subtle);
-		font-size: 0.95rem;
-		line-height: 1.6;
+		font-size: clamp(1rem, 1.3vw, 1.1rem);
+		line-height: 1.65;
 	}
 
 	.more-grid {
@@ -430,7 +455,11 @@
 		text-decoration: none;
 	}
 
-	.aside-link:hover {
+	// BlockHead's shared `.aside :global(a:hover)` rule underlines the whole
+	// anchor (including the icon glyph) and, since it targets the bare `a`
+	// element, it out-specifies a same-weight class selector here. Scope through
+	// `.aside` too so this reset wins instead of relying on source order.
+	:global(.aside) .aside-link:hover {
 		text-decoration: none;
 	}
 
@@ -447,6 +476,26 @@
 		transform: translateX(3px);
 	}
 
+	.contact-grid {
+		display: grid;
+		grid-template-columns: 0.75fr 1.25fr;
+		gap: clamp(1.75rem, 4.5vw, 3.75rem);
+		align-items: start;
+	}
+
+	.contact-details {
+		display: grid;
+		gap: 0.6rem;
+		align-content: start;
+	}
+
+	.contact-details p {
+		font-size: clamp(1rem, 1.3vw, 1.1rem);
+		color: var(--color-subtle);
+		line-height: 1.65;
+		margin: 0;
+	}
+
 	.gallery-fade {
 		position: relative;
 		max-height: clamp(260px, 32vw, 340px);
@@ -455,30 +504,58 @@
 		mask-image: linear-gradient(to bottom, #000 55%, transparent 100%);
 	}
 
+	// Full covers stay solid; only the caption fades — the shelf wraps to a
+	// single row at 4 books, so there's no extra content to tease/hide here.
+	.shelf-fade {
+		position: relative;
+		overflow: hidden;
+		-webkit-mask-image: linear-gradient(to bottom, #000 78%, transparent 100%);
+		mask-image: linear-gradient(to bottom, #000 78%, transparent 100%);
+	}
+
+	// Below this the shelf wraps to two rows, so switch to the same
+	// crop-and-tease treatment the mobile view already uses.
+	@media (max-width: 760px) {
+		.shelf-fade {
+			max-height: clamp(280px, 78vw, 340px);
+			-webkit-mask-image: linear-gradient(to bottom, #000 65%, transparent 100%);
+			mask-image: linear-gradient(to bottom, #000 65%, transparent 100%);
+		}
+	}
+
 	@media (max-width: 820px) {
 		.hero-grid {
 			grid-template-columns: 1fr;
-			gap: 1.75rem;
+			gap: 1.1rem;
 			text-align: center;
 			justify-items: center;
 		}
 
+		// Flatten the copy block so the portrait can be ordered between the blurb
+		// and the CTAs rather than sitting above the heading.
 		.hero-copy {
-			justify-items: center;
+			display: contents;
+		}
+
+		.hero-copy h1 {
+			order: 1;
 		}
 
 		.hero-body {
+			order: 2;
 			margin-inline: auto;
 		}
 
-		.hero-ctas {
-			justify-content: center;
-		}
-
 		.hero-portrait {
-			order: -1;
+			order: 3;
 			justify-self: center;
 			width: min(220px, 60vw);
+			margin-block: 0.35rem;
+		}
+
+		.hero-ctas {
+			order: 4;
+			justify-content: center;
 		}
 
 		.currently-item {
@@ -490,13 +567,20 @@
 		}
 	}
 
+	@media (max-width: 800px) {
+		.contact-grid {
+			grid-template-columns: 1fr;
+			gap: 1.5rem;
+		}
+	}
+
 	@media (max-width: 620px) {
 		.intro {
 			margin-inline: auto;
 		}
 
 		.gallery-fade {
-			max-height: clamp(200px, 60vw, 260px);
+			max-height: clamp(300px, 85vw, 360px);
 		}
 
 		.row {


### PR DESCRIPTION
## Summary
- Replaced the homepage "More" section with an inline contact form (matching the legacy site's "Get in touch" treatment), removing the standalone email link in favor of the form.
- Reworked the book notes shelf from a horizontal-scroll layout to a responsive CSS subgrid that wraps evenly at each breakpoint (5 → 3 → 2 columns), with a caption-fade effect matching the photography gallery's teaser style at every screen width instead of just mobile.
- Fixed a cross-component CSS specificity bug where hovering an aside-link (e.g. "See all") underlined the arrow icon glyph along with the label text.
- Tightened mobile nav menu item spacing and unified homepage paragraph font sizes against the hero blurb.
- Reverted an in-progress, unlicensed trial-font swap (Rationell) back to Poppins for `--font-heading`.
- Added `.claude/launch.json` so the dev server can be started via the Browser preview tooling.

## Test plan
- [x] Verified in-browser at mobile (375px), tablet (~700px), and desktop (1000–1280px) widths that the book shelf wraps without orphaned rows and the fade/shadow renders correctly at every breakpoint.
- [x] Confirmed the contact section, "Contact me" aside link, and hover states (no stray underline on icons) render correctly.
- [x] Confirmed Poppins loads (`document.fonts`) and no requests are made for the old Rationell font files.
- [ ] Manual review of copy/tagline (footer tagline change was discussed but not applied — still "thanks for stopping by").

🤖 Generated with [Claude Code](https://claude.com/claude-code)