### PR TITLE
Polish homepage/book/photo copy, fix hover-clip and radius consistency

### DIFF
--- a/personal-website/src/lib/components/site/BookCard.svelte
+++ b/personal-website/src/lib/components/site/BookCard.svelte
@@ -33,7 +33,7 @@
 	.cover-wrap {
 		position: relative;
 		aspect-ratio: 2 / 3;
-		border-radius: 3px 5px 5px 3px;
+		border-radius: var(--radius-sm) var(--radius-md) var(--radius-md) var(--radius-sm);
 		filter: drop-shadow(0 6px 12px rgb(36 37 37 / 0.18))
 			drop-shadow(0 2px 4px rgb(36 37 37 / 0.1));
 		transition: filter 0.3s ease;
@@ -44,7 +44,7 @@
 		width: 100%;
 		height: 100%;
 		object-fit: cover;
-		border-radius: 3px 5px 5px 3px;
+		border-radius: var(--radius-sm) var(--radius-md) var(--radius-md) var(--radius-sm);
 	}
 
 	.spine {
@@ -57,7 +57,7 @@
 			rgb(0 0 0 / 0.08) 55%,
 			rgb(255 255 255 / 0.15) 100%
 		);
-		border-radius: 3px 0 0 3px;
+		border-radius: var(--radius-sm) 0 0 var(--radius-sm);
 		pointer-events: none;
 	}
 

--- a/personal-website/src/lib/components/site/BookStack.svelte
+++ b/personal-website/src/lib/components/site/BookStack.svelte
@@ -88,7 +88,7 @@
 		position: relative;
 		display: block;
 		aspect-ratio: 2 / 3;
-		border-radius: 3px 5px 5px 3px;
+		border-radius: var(--radius-sm) var(--radius-md) var(--radius-md) var(--radius-sm);
 		filter: drop-shadow(0 8px 14px rgb(36 37 37 / 0.16)) drop-shadow(0 2px 4px rgb(36 37 37 / 0.1));
 		transition:
 			transform var(--duration-base) cubic-bezier(0.2, 0.8, 0.2, 1),
@@ -100,7 +100,7 @@
 		width: 100%;
 		height: 100%;
 		object-fit: cover;
-		border-radius: 3px 5px 5px 3px;
+		border-radius: var(--radius-sm) var(--radius-md) var(--radius-md) var(--radius-sm);
 	}
 
 	.spine {
@@ -113,12 +113,13 @@
 			rgb(0 0 0 / 0.06) 60%,
 			rgb(255 255 255 / 0.16) 100%
 		);
-		border-radius: 3px 0 0 3px;
+		border-radius: var(--radius-sm) 0 0 var(--radius-sm);
 		pointer-events: none;
 	}
 
 	.meta {
 		display: grid;
+		align-content: start;
 		gap: 0.2rem;
 		padding-top: 0.85rem;
 		border-top: 1px solid var(--color-line);

--- a/personal-website/src/lib/components/site/Footer.svelte
+++ b/personal-website/src/lib/components/site/Footer.svelte
@@ -87,7 +87,7 @@
 		display: inline-flex;
 		align-items: center;
 		justify-content: center;
-		color: var(--color-subtle);
+		color: var(--color-ink);
 		text-decoration: none;
 		transition:
 			color var(--duration-fast) ease,

--- a/personal-website/src/lib/components/site/Garden.svelte
+++ b/personal-website/src/lib/components/site/Garden.svelte
@@ -71,7 +71,6 @@
 	let canRevealed = $state(false);
 
 	function onTreeClick(key: TreeKey) {
-		glow[key] = 1;
 		if (canRevealed) return;
 		treeClicks += 1;
 		if (treeClicks >= 3) canRevealed = true;
@@ -669,12 +668,6 @@
 		outline: none;
 	}
 
-	.tree:focus-visible {
-		outline: 2px solid var(--color-green-soft);
-		outline-offset: 4px;
-		border-radius: 4px;
-	}
-
 	.main {
 		width: clamp(64px, 6.2vw, 80px);
 	}
@@ -801,7 +794,7 @@
 	.watering-can:focus-visible {
 		outline: 2px solid var(--color-green-soft);
 		outline-offset: 4px;
-		border-radius: 4px;
+		border-radius: var(--radius-sm);
 	}
 
 	@media (prefers-reduced-motion: reduce) {

--- a/personal-website/src/lib/content/pages.ts
+++ b/personal-website/src/lib/content/pages.ts
@@ -6,14 +6,14 @@ export const homePage = {
 		title: 'Matej Groombridge',
 		description:
 			'Hi, my name is Matej Groombridge. I\'m a second year undergraduate student, UNSW ' +
-			'Co-op Scholar and Sydney-based Software Engineer, currently interning at Atlassian. ' +
+			'Co-op Scholar and Sydney-based Software Engineer, and ex-Atlassian intern. ' +
 			'Thanks for stopping by!'
 	},
 	hero: {
 		title: 'Hi, I\'m\nMatej.',
 		body:
 			'I\'m a second year undergraduate student, UNSW Co-op Scholar and Sydney-based ' +
-			'Software Engineer, currently interning at Atlassian.',
+			'Software Engineer, and ex-Atlassian intern.',
 		image: {
 			src: '/frontpage2.webp',
 			alt: 'Matej Groombridge',
@@ -36,17 +36,16 @@ export type HomeCurrentlyItem = {
 
 export const homeCurrently: HomeCurrentlyItem[] = [
 	{ icon: 'place', label: 'Based in', value: 'Sydney, Australia' },
-	{ icon: 'work', label: 'Interning at', value: 'Atlassian' },
+	{ icon: 'work', label: 'Interned at', value: 'Atlassian' },
 	{ icon: 'school', label: 'Studying', value: 'Software Engineering · UNSW Co-op' },
 	// { icon: 'self_improvement', label: 'Focused on', value: 'Build more, scroll less' }
 ];
 
 export const homeIntro = {
-	eyebrow: 'About this site',
-	title: 'what this actually is',
 	body:
-		'some software I\'m building, books I\'m reading, photos I\'m taking, and ideas I can\'t ' +
-		'stop turning over. no schedule, no algorithm — just the stuff I actually care about.'
+		'hey — I\'m Matej, 20, based in Sydney. this is just my corner of the internet: photos ' +
+		'I\'ve taken, stuff I\'m building, books I\'m reading, whatever\'s on my mind. no real plan ' +
+		'behind it, it just changes as I do. thanks for stopping by.'
 };
 
 type HomeBlockMeta = {
@@ -75,25 +74,25 @@ export const homeSections: {
 		title: 'Writing',
 		asideLabel: 'Read all',
 		asideHref: '/writing',
-		intro: 'Short essays on software, learning, and the things I keep thinking about.'
+		intro: 'I\'m picking up essay writing to refine my thoughts on topics that matter to me.'
 	},
 	photography: {
 		title: 'Photography',
 		asideLabel: 'See all',
 		asideHref: '/photography',
-		intro: 'an archive of cool places I\'ve photographed over the years — a few recent favourites below.'
+		intro: 'an archive — cool places I\'ve photographed over the years.'
 	},
 	booknotes: {
 		title: 'Book Notes',
-		asideLabel: 'Read all',
+		asideLabel: 'all books',
 		asideHref: '/booknotes',
-		intro: 'key takeaways etc. from books I\'ve read — lifestyle, philosophy, tech, whatever\'s interesting.'
+		intro: 'notes, quotes, reviews and key takeaways from books I\'ve read.'
 	},
 	contact: {
 		title: 'Get in touch',
 		asideLabel: 'Contact me',
 		asideHref: '/contact',
-		intro: 'got a question, a project, or just want to say hi? send a note and I\'ll reply asap.'
+		intro: 'send a message and I\'ll get back to you when I can.'
 	},
 	more: { title: 'More' }
 };
@@ -125,7 +124,7 @@ export const bookNotesPage = {
 	hero: {
 		eyebrow: 'Book Notes',
 		title: 'notes, quotes and reviews',
-		body: 'key takeaways etc. from books I\'ve read'
+		body: 'key takeaways and more from books I\'ve read.'
 	},
 	sections: []
 } as const satisfies PageContent;
@@ -139,7 +138,7 @@ export const photographyPage = {
 	hero: {
 		eyebrow: 'Photography',
 		title: 'Travel photography',
-		body: 'an archive — cool places I\'ve photographed over the years'
+		body: 'an archive — cool places I\'ve photographed over the years.'
 	},
 	sections: []
 } as const satisfies PageContent;

--- a/personal-website/src/lib/content/year2026.ts
+++ b/personal-website/src/lib/content/year2026.ts
@@ -87,7 +87,7 @@ export const year2026Projects: Project[] = [
 
 export const year2026Currently: CurrentlyItem[] = [
 	{ icon: 'place', label: 'Based in', value: 'Sydney, Australia' },
-	{ icon: 'code', label: 'Working on', value: 'Atlassian + this site' },
+	{ icon: 'code', label: 'Working on', value: 'this site' },
 	{ icon: 'menu_book', label: 'Reading', value: 'See book notes' },
 	// { icon: 'self_improvement', label: 'Focused on', value: 'Build more, scroll less' }
 ];

--- a/personal-website/src/routes/+page.svelte
+++ b/personal-website/src/routes/+page.svelte
@@ -67,8 +67,8 @@
 				<img
 					src={homePage.hero.image.src}
 					alt={homePage.hero.image.alt}
-					width="320"
-					height="400"
+					width="260"
+					height="325"
 					loading="eager"
 				/>
 			</div>
@@ -103,7 +103,6 @@
 		{/snippet}
 	</BlockHead>
 	<div class="about">
-		<h2>{homeIntro.title}</h2>
 		<p>{homeIntro.body}</p>
 	</div>
 </Section>
@@ -160,9 +159,7 @@
 		{/snippet}
 	</BlockHead>
 	<p class="intro">{homeSections.booknotes.intro}</p>
-	<div class="shelf-fade">
-		<BookStack books={featuredBooks} pool={bookPool} count={5} />
-	</div>
+	<BookStack books={featuredBooks} pool={bookPool} count={5} />
 </Section>
 
 {#if false}
@@ -213,7 +210,7 @@
 
 	.hero-grid {
 		display: grid;
-		grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
+		grid-template-columns: minmax(0, 1fr) minmax(180px, 260px);
 		gap: clamp(1.5rem, 5vw, 4rem);
 		align-items: center;
 	}
@@ -249,7 +246,7 @@
 
 	.hero-portrait {
 		justify-self: end;
-		width: min(320px, 100%);
+		width: min(260px, 100%);
 	}
 
 	.hero-portrait img {
@@ -500,27 +497,10 @@
 		position: relative;
 		max-height: clamp(260px, 32vw, 340px);
 		overflow: hidden;
+		padding-top: 6px;
+		margin-top: -6px;
 		-webkit-mask-image: linear-gradient(to bottom, #000 55%, transparent 100%);
 		mask-image: linear-gradient(to bottom, #000 55%, transparent 100%);
-	}
-
-	// Full covers stay solid; only the caption fades — the shelf wraps to a
-	// single row at 4 books, so there's no extra content to tease/hide here.
-	.shelf-fade {
-		position: relative;
-		overflow: hidden;
-		-webkit-mask-image: linear-gradient(to bottom, #000 78%, transparent 100%);
-		mask-image: linear-gradient(to bottom, #000 78%, transparent 100%);
-	}
-
-	// Below this the shelf wraps to two rows, so switch to the same
-	// crop-and-tease treatment the mobile view already uses.
-	@media (max-width: 760px) {
-		.shelf-fade {
-			max-height: clamp(280px, 78vw, 340px);
-			-webkit-mask-image: linear-gradient(to bottom, #000 65%, transparent 100%);
-			mask-image: linear-gradient(to bottom, #000 65%, transparent 100%);
-		}
 	}
 
 	@media (max-width: 820px) {

--- a/personal-website/src/routes/2026/+page.svelte
+++ b/personal-website/src/routes/2026/+page.svelte
@@ -46,21 +46,25 @@
 
 <Section id="projects">
 	<BlockHead title="Projects" />
-	<ul class="project-grid">
-		{#each year2026Projects as project}
-			<li>
-				<button type="button" class="project" onclick={() => openProject(project)}>
-					<span class="project-icon" aria-hidden="true">
-						<span class="material-symbols-rounded">{project.icon ?? 'bolt'}</span>
-					</span>
-					<div class="project-body">
-						<h3>{project.title}</h3>
-						<p>{project.description}</p>
-					</div>
-				</button>
-			</li>
-		{/each}
-	</ul>
+	{#if false}
+		<ul class="project-grid">
+			{#each year2026Projects as project}
+				<li>
+					<button type="button" class="project" onclick={() => openProject(project)}>
+						<span class="project-icon" aria-hidden="true">
+							<span class="material-symbols-rounded">{project.icon ?? 'bolt'}</span>
+						</span>
+						<div class="project-body">
+							<h3>{project.title}</h3>
+							<p>{project.description}</p>
+						</div>
+					</button>
+				</li>
+			{/each}
+		</ul>
+	{:else}
+		<p class="placeholder">I'm in the process of updating this section — check back soon.</p>
+	{/if}
 </Section>
 
 <!-- <Section id="focus">
@@ -94,6 +98,11 @@
 <ProjectModal project={activeProject} onclose={closeProject} />
 
 <style lang="scss">
+	.placeholder {
+		color: var(--color-subtle);
+		font-size: 0.95rem;
+	}
+
 	.project-grid {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));

--- a/personal-website/src/routes/booknotes/[slug]/+page.svelte
+++ b/personal-website/src/routes/booknotes/[slug]/+page.svelte
@@ -103,7 +103,7 @@
 	.hero-cover img {
 		width: clamp(180px, 22vw, 270px);
 		height: auto;
-		border-radius: 4px 8px 8px 4px;
+		border-radius: var(--radius-sm) var(--radius-md) var(--radius-md) var(--radius-sm);
 		box-shadow:
 			0 18px 38px rgb(36 37 37 / 0.18),
 			0 4px 10px rgb(36 37 37 / 0.1);


### PR DESCRIPTION
## Summary
- Removed the bottom shadow on the homepage book shelf and fixed a hover-clip bug where the top-row photo cards got cut off on hover; shrank and re-centered the hero portrait.
- Synced homepage section intros (photography, book notes, contact) with the actual page copy, and rewrote the About blurb to sound more natural.
- Updated bio copy site-wide to reflect the Atlassian internship has ended.
- Standardized the book-cover corner radius onto the `--radius-sm`/`--radius-md` tokens across `BookCard`, `BookStack`, and the book detail hero cover.
- Stopped the garden bonsai trees' green glow/focus-ring from firing on click — it's now reserved for the watering-can interaction.
- Placeholdered the 2026 page's Projects section while it's reworked (original markup preserved behind `{#if false}`).

## Test plan
- [x] Verified all copy changes render correctly in the browser (light + dark themes)
- [x] Verified the photo-card hover no longer clips at the top of the gallery
- [x] Verified book cover radii render consistently across the home shelf, book notes grid, and book detail page
- [x] Confirmed clicking a bonsai tree no longer triggers the green glow filter (watering still does)
- [x] `svelte-check` shows no new errors introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)