### PR TITLE
Swap body text to Figtree, tighten hero copy and footer wordmark

### DIFF
--- a/legacy/src/css/app.css
+++ b/legacy/src/css/app.css
@@ -1,7 +1,7 @@
 @import url("https://fonts.googleapis.com/css2?family=Poppins:wght@200;400;500;600;700;900&display=swap");
-@import url("https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,200;0,400;0,700;0,900;1,400&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,300..900;1,300..900&display=swap");
 :root {
-  font-family: "Montserrat", Helvetica, sans-serif;
+  font-family: "Figtree", Helvetica, sans-serif;
 }
 
 * {
@@ -95,7 +95,7 @@ p {
   font-size: 19px;
   line-height: 1.6em;
   margin: 0.5em 0;
-  font-family: "Montserrat", Helvetica, sans-serif;
+  font-family: "Figtree", Helvetica, sans-serif;
 }
 
 a img {
@@ -193,7 +193,7 @@ section {
   margin: 0 1em;
   font-size: 19px;
   line-height: 1.6em;
-  font-family: "Montserrat", Helvetica, sans-serif;
+  font-family: "Figtree", Helvetica, sans-serif;
 }
 .article a {
   font-size: 17px;
@@ -286,14 +286,14 @@ td:last-child {
   font-size: 22px;
   margin: 0.5em 0;
   line-height: 1.7em;
-  font-family: "Montserrat", Helvetica, sans-serif;
+  font-family: "Figtree", Helvetica, sans-serif;
 }
 
 .medium-text {
   font-size: 19px;
   margin: 0.5em 1em 2em 1em;
   line-height: 1.7em;
-  font-family: "Montserrat", Helvetica, sans-serif;
+  font-family: "Figtree", Helvetica, sans-serif;
 }
 
 .testimonial-text {
@@ -900,7 +900,7 @@ input {
   border-radius: 0.25em;
   height: 2.5em;
   width: 100%;
-  font-family: "Montserrat", Helvetica, sans-serif;
+  font-family: "Figtree", Helvetica, sans-serif;
   font-size: 16px;
   color: #242525;
 }
@@ -911,7 +911,7 @@ select {
   border-radius: 0.25em;
   height: 2.5em;
   width: 100%;
-  font-family: "Montserrat", Helvetica, sans-serif;
+  font-family: "Figtree", Helvetica, sans-serif;
   font-size: 16px;
   color: #242525;
 }
@@ -923,7 +923,7 @@ textarea {
   width: 100%;
   height: 250px;
   resize: none;
-  font-family: "Montserrat", Helvetica, sans-serif;
+  font-family: "Figtree", Helvetica, sans-serif;
   font-size: 16px;
   color: #242525;
   line-height: 1.4em;

--- a/legacy/src/css/app.scss
+++ b/legacy/src/css/app.scss
@@ -1,9 +1,9 @@
 @import '_variables.scss';
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@200;400;500;600;700;900&display=swap'); //Poppins
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,200;0,400;0,700;0,900;1,400&display=swap'); //Montserrat
+@import url('https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,300..900;1,300..900&display=swap'); //Figtree
 
 :root {
-	font-family: 'Montserrat', Helvetica, sans-serif;
+	font-family: 'Figtree', Helvetica, sans-serif;
 }
 
 * {
@@ -121,7 +121,7 @@ p {
 	line-height: 1.6em;
 	margin: 0.5em 0;
 
-	font-family: 'Montserrat', Helvetica, sans-serif;
+	font-family: 'Figtree', Helvetica, sans-serif;
 }
 
 a img {
@@ -224,7 +224,7 @@ section {
 		font-size: 19px;
 		line-height: 1.6em;
 
-		font-family: 'Montserrat', Helvetica, sans-serif;
+		font-family: 'Figtree', Helvetica, sans-serif;
 	}
 
 	a {
@@ -327,14 +327,14 @@ td:last-child {
 	margin: 0.5em 0;
 	line-height: 1.7em;
 
-	font-family: 'Montserrat', Helvetica, sans-serif;
+	font-family: 'Figtree', Helvetica, sans-serif;
 }
 
 .medium-text {
 	font-size: 19px;
 	margin: 0.5em 1em 2em 1em;
 	line-height: 1.7em;
-	font-family: 'Montserrat', Helvetica, sans-serif;
+	font-family: 'Figtree', Helvetica, sans-serif;
 }
 
 .testimonial-text {
@@ -1042,7 +1042,7 @@ input {
 	height: 2.5em;
 	width: 100%;
 
-	font-family: 'Montserrat', Helvetica, sans-serif;
+	font-family: 'Figtree', Helvetica, sans-serif;
 	font-size: 16px;
 	color: $text-color;
 }
@@ -1055,7 +1055,7 @@ select {
 	height: 2.5em;
 	width: 100%;
 
-	font-family: 'Montserrat', Helvetica, sans-serif;
+	font-family: 'Figtree', Helvetica, sans-serif;
 	font-size: 16px;
 	color: $text-color;
 }
@@ -1070,7 +1070,7 @@ textarea {
 
 	resize: none;
 
-	font-family: 'Montserrat', Helvetica, sans-serif;
+	font-family: 'Figtree', Helvetica, sans-serif;
 	font-size: 16px;
 	color: $text-color;
 

--- a/personal-website/src/lib/components/site/Footer.svelte
+++ b/personal-website/src/lib/components/site/Footer.svelte
@@ -11,7 +11,7 @@
 	<Container>
 		<div class="inner">
 			<div class="about">
-				<p class="title">{siteSettings.name}</p>
+				<p class="title" data-preserve-case>{siteSettings.name.toUpperCase()}</p>
 				<p class="tagline">{siteSettings.tagline}</p>
 				<LocalTime />
 			</div>
@@ -62,7 +62,10 @@
 		font-family: var(--font-heading);
 		font-weight: 700;
 		font-size: 1rem;
-		letter-spacing: 0.02em;
+		// Matches the header brand: uppercase needs the wider tracking to stop
+		// the caps closing up on each other.
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
 	}
 
 	.tagline {

--- a/personal-website/src/lib/content/pages.ts
+++ b/personal-website/src/lib/content/pages.ts
@@ -11,9 +11,9 @@ export const homePage = {
 	},
 	hero: {
 		title: 'Hi, I\'m\nMatej.',
-		body:
-			'I\'m a second year undergraduate student, UNSW Co-op Scholar and Sydney-based ' +
-			'Software Engineer, and ex-Atlassian intern.',
+		// Non-breaking space between 'UNSW' and 'co-op' so the phrase never
+		// splits across a line break on narrow screens.
+		body: 'sydney-based software engineer — UNSW\u00A0co-op scholar, previously at Atlassian',
 		image: {
 			src: '/frontpage2.webp',
 			alt: 'Matej Groombridge',

--- a/personal-website/src/lib/content/proper-nouns.ts
+++ b/personal-website/src/lib/content/proper-nouns.ts
@@ -21,7 +21,6 @@ export const properNouns: string[] = [
 
 	// Education / work
 	'UNSW',
-	'Co-op',
 	'Atlassian',
 
 	// Tech / brands

--- a/personal-website/src/lib/design/global.scss
+++ b/personal-website/src/lib/design/global.scss
@@ -1,5 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700;900&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,400;0,600;0,700;1,400&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,300..900;1,300..900&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@500;600;700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT@9..144,400..700,50&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,400,0,0&display=swap');
@@ -28,7 +28,7 @@ $subtle: #4d524f;
 	--color-surface: #fffdf8;
 	--color-border: rgb(36 37 37 / 0.08);
 	--color-header-border: rgb(36 37 37 / 0.06);
-	--font-body: 'Montserrat', Helvetica, sans-serif;
+	--font-body: 'Figtree', Helvetica, sans-serif;
 	--font-heading: 'Poppins', Helvetica, sans-serif;
 	--font-display: 'Fraunces', 'Iowan Old Style', Georgia, serif;
 	--size-page: min(880px, calc(100vw - clamp(2.5rem, 6vw, 3rem)));


### PR DESCRIPTION
## What changed

Two unrelated-but-small things, kept together because they're all one-line content/style tweaks to the home page and chrome.

### Body font: Montserrat → Figtree

`--font-body` on the new site and the root body font on the legacy site both move from Montserrat to Figtree, so the two codebases share one sans. Loaded as a variable font (`300..900` + italics) in place of Montserrat's fixed weights.

**Headline type is deliberately untouched.** Poppins still carries `--font-heading` and Fraunces `--font-display` on the new site; Poppins still carries headings/links on legacy. Only non-heading text changed.

In legacy, all eight Montserrat usages were body-level (`:root`, `p`, `li`, `.body-text`, `.medium-text`, and three form inputs), so the swap is mechanical. Both `app.scss` and the committed compiled `app.css` are updated in step.

### Hero copy

Before: `I'm a second year undergraduate student, UNSW Co-op Scholar and Sydney-based Software Engineer, and ex-Atlassian intern.`

After: `sydney-based software engineer — UNSW co-op scholar, previously at Atlassian`

Same facts, about half the length, and it scans. Note the ` ` between "UNSW" and "co-op" — without it the mobile wrap orphaned "UNSW" at the end of line one and split the phrase. With it, the break falls at the em dash and both lines are complete phrases. It's written as an explicit escape rather than a raw byte so it survives future find-and-replace.

### Casing

- **`Co-op` removed from the proper-noun allowlist** (`proper-nouns.ts`), so it lowercases along with everything else under the site-wide lowercase treatment. Also affects the "Studying" stat.
- **Footer wordmark now uppercase**, matching the header.

The footer change needs explaining, because the obvious fix doesn't work. `"Matej Groombridge"` is in the proper-noun list, so `preserveCase.ts` wraps it in a `<span data-preserve-case>`, and `global.scss` gives that span `text-transform: none !important` — which beats a component-scoped `text-transform: uppercase`. So the footer mirrors what the header already does: `.toUpperCase()` in markup **plus** `data-preserve-case` on the element. Tracking also widened `0.02em → 0.06em` to match the header, since caps close up at body tracking. Weight and size intentionally left different from the header.

## Reviewer notes

- Verified in the browser at desktop and 375px: hero renders on one line at desktop and wraps at the em dash on mobile; footer reads `MATEJ GROOMBRIDGE`; `co-op` lowercases while `UNSW` and `Atlassian` keep their caps; no console errors.
- `pnpm validate:content` passes (31 book notes, 13 photo trips).
- `prettier --check` and `eslint` both report **pre-existing** failures on files this PR doesn't touch (13 and 6 files respectively). I ran Prettier on `pages.ts` at one point and it rewrote 40+ unrelated lines (quote style, trailing commas), so I reverted that and kept the diff minimal in the file's existing style. Worth a separate formatting pass, but not here.
- **Known inconsistency, left for a decision:** the hero says `sydney-based` (lowercase) while the footer's location line says `Sydney`. `Sydney` is in the proper-noun allowlist and the matcher is case-sensitive, so lowercase source slips past it. Either capitalise the hero or drop `Sydney` from the allowlist — one line either way.
- **Not changed:** the SEO meta description still carries the old long bio. Prose arguably suits a meta description better than the hero line, so I left it rather than assume.
- Branch name (`...garamond-figtree`) is a leftover from an earlier EB Garamond experiment that was reverted before this commit. The branch was force-pushed to drop it; no Garamond remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
