### PR TITLE
Add temporary /lab page of design concepts

### DIFF
--- a/personal-website/package.json
+++ b/personal-website/package.json
@@ -21,6 +21,7 @@
 		"@sveltejs/adapter-netlify": "^5.2.4",
 		"@sveltejs/kit": "^2.57.0",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
+		"@types/matter-js": "^0.20.2",
 		"@types/node": "^25.9.1",
 		"eslint": "^9.39.4",
 		"eslint-config-prettier": "^10.1.8",
@@ -41,6 +42,7 @@
 		"@fortawesome/fontawesome-svg-core": "^6.7.2",
 		"@fortawesome/free-brands-svg-icons": "^6.7.2",
 		"@fortawesome/svelte-fontawesome": "^0.2.4",
-		"@humanspeak/svelte-markdown": "^0.8.17"
+		"@humanspeak/svelte-markdown": "^0.8.17",
+		"matter-js": "^0.20.0"
 	}
 }

--- a/personal-website/src/routes/lab/+page.svelte
+++ b/personal-website/src/routes/lab/+page.svelte
@@ -291,6 +291,11 @@
 				Try <kbd data-preserve-case>⌘K</kbd> anywhere on this page, and flip the site into dark mode with
 				the header toggle — everything below is built for both.
 			</p>
+			<a class="sibling" href="/lab/chrome">
+				<span class="lab-mono sibling-label">also in the lab</span>
+				<span class="sibling-title" data-preserve-case>Headers &amp; footers →</span>
+				<span class="sibling-note">Ten of each, with a working width switcher.</span>
+			</a>
 		</div>
 	</header>
 
@@ -529,6 +534,43 @@
 		border-bottom-width: 2px;
 		border-radius: var(--radius-sm);
 		background: var(--color-muted);
+	}
+
+	.sibling {
+		display: grid;
+		gap: 0.15rem;
+		margin-top: 0.5rem;
+		padding: 0.7rem 1rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-md);
+		background: var(--color-surface);
+		text-decoration: none;
+		transition:
+			border-color var(--duration-fast) ease,
+			transform var(--duration-fast) ease;
+	}
+
+	.sibling:hover {
+		border-color: var(--lab-accent);
+		transform: translateY(-2px);
+	}
+
+	.sibling-label {
+		font-size: 0.5rem;
+		color: var(--lab-accent);
+	}
+
+	.sibling-title {
+		font-family: var(--font-ui);
+		font-size: 0.95rem;
+		font-weight: 650;
+		letter-spacing: -0.02em;
+		color: var(--color-heading);
+	}
+
+	.sibling-note {
+		font-size: 0.8rem;
+		color: var(--color-subtle);
 	}
 
 	.layout {

--- a/personal-website/src/routes/lab/+page.svelte
+++ b/personal-website/src/routes/lab/+page.svelte
@@ -1,0 +1,675 @@
+<script lang="ts">
+	// ---------------------------------------------------------------------------
+	// TEMPORARY design-concept sandbox.
+	//
+	// This whole route is disposable: nothing outside `src/routes/lab/` imports
+	// from it, and deleting the folder (plus the `matter-js` dependency, if the
+	// physics concept is not kept) removes it completely.
+	// ---------------------------------------------------------------------------
+	import { onMount } from 'svelte';
+	import './lab.scss';
+
+	import ConceptFrame from './concepts/ConceptFrame.svelte';
+	import AuroraHero from './concepts/AuroraHero.svelte';
+	import Bookshelf from './concepts/Bookshelf.svelte';
+	import CommandPalette from './concepts/CommandPalette.svelte';
+	import Constellation from './concepts/Constellation.svelte';
+	import ContactSheet from './concepts/ContactSheet.svelte';
+	import ElasticNav from './concepts/ElasticNav.svelte';
+	import HorizontalRail from './concepts/HorizontalRail.svelte';
+	import HoverPreviewList from './concepts/HoverPreviewList.svelte';
+	import KineticMasthead from './concepts/KineticMasthead.svelte';
+	import Marginalia from './concepts/Marginalia.svelte';
+	import MegaFooter from './concepts/MegaFooter.svelte';
+	import PhotoDeck from './concepts/PhotoDeck.svelte';
+	import PhysicsTags from './concepts/PhysicsTags.svelte';
+	import ReactionBar from './concepts/ReactionBar.svelte';
+	import ScrollTimeline from './concepts/ScrollTimeline.svelte';
+	import SpotlightGrid from './concepts/SpotlightGrid.svelte';
+	import StatsStrip from './concepts/StatsStrip.svelte';
+	import StatusOrb from './concepts/StatusOrb.svelte';
+	import TextTreatments from './concepts/TextTreatments.svelte';
+	import ThemeStudio from './concepts/ThemeStudio.svelte';
+	import VelocityTicker from './concepts/VelocityTicker.svelte';
+	import YearGrid from './concepts/YearGrid.svelte';
+
+	type ConceptMeta = {
+		id: string;
+		title: string;
+		tagline: string;
+		slot: string;
+		tags: string[];
+	};
+
+	// Single source of truth for the index rail, the section headers and the
+	// numbering — so nothing can drift out of sync as concepts are cut.
+	const concepts: ConceptMeta[] = [
+		{
+			id: 'kinetic-masthead',
+			title: 'Kinetic masthead',
+			tagline:
+				'The name is set in a variable font and every glyph reacts to the cursor — weight, optical size and softness all move at once.',
+			slot: 'home hero',
+			tags: ['variable font', 'pointer', 'rAF']
+		},
+		{
+			id: 'aurora-hero',
+			title: 'Aurora hero',
+			tagline:
+				'A quarter-resolution canvas of drifting colour, blurred into a gradient field, with film grain over the top. Reads the theme, pauses off-screen.',
+			slot: 'home hero',
+			tags: ['canvas', 'theme-aware', 'grain']
+		},
+		{
+			id: 'command-palette',
+			title: 'Command palette',
+			tagline:
+				'⌘K opens one fuzzy index over every page, book note, trip and site action. The most useful thing on this page.',
+			slot: 'site-wide',
+			tags: ['⌘K', 'fuzzy search', 'keyboard']
+		},
+		{
+			id: 'stats-strip',
+			title: 'Counting stats',
+			tagline:
+				'Numbers count up once when the strip is scrolled into view, each with a sparkline derived from the real data behind it.',
+			slot: 'about / home',
+			tags: ['count-up', 'sparkline']
+		},
+		{
+			id: 'spotlight-grid',
+			title: 'Spotlight grid',
+			tagline:
+				'One shared torch follows the cursor across the whole grid while each card lights its own gradient border by proximity.',
+			slot: 'home index',
+			tags: ['mask border', 'proximity']
+		},
+		{
+			id: 'velocity-ticker',
+			title: 'Velocity ticker',
+			tagline:
+				'A two-lane marquee whose speed, skew and font weight are all driven by how fast you are scrolling.',
+			slot: 'section divider',
+			tags: ['scroll velocity', 'variable font']
+		},
+		{
+			id: 'text-treatments',
+			title: 'Three text treatments',
+			tagline:
+				'A decode scramble, a hand-drawn marker highlight that draws itself, and a word-by-word focus pull.',
+			slot: 'headings',
+			tags: ['scramble', 'svg', 'stagger']
+		},
+		{
+			id: 'elastic-nav',
+			title: 'Elastic segmented nav',
+			tagline:
+				'The indicator is driven by a spring, not a transition — it squashes along its travel and leans toward whatever you hover.',
+			slot: 'filters / nav',
+			tags: ['spring', 'squash & stretch']
+		},
+		{
+			id: 'hover-preview-list',
+			title: 'Hover-preview index',
+			tagline:
+				'A dense text index where the cover trails the cursor with lag and tilt, and every other row recedes.',
+			slot: 'book notes index',
+			tags: ['cursor follow', 'dimming']
+		},
+		{
+			id: 'bookshelf',
+			title: '3D bookshelf',
+			tagline:
+				'Real spines standing on a real shelf in CSS 3D. Hover pulls a book out and turns it to face you; drag to pan the shelf.',
+			slot: 'book notes',
+			tags: ['css 3d', 'drag']
+		},
+		{
+			id: 'contact-sheet',
+			title: 'Film contact sheet',
+			tagline:
+				'Each trip is a strip of 35mm. Sweeping across a frame scrubs through the roll, frame counter and all.',
+			slot: 'photography index',
+			tags: ['scrub', 'film']
+		},
+		{
+			id: 'photo-deck',
+			title: 'Throwable photo deck',
+			tagline:
+				'A physical card stack. Drag past the threshold to throw a photo away and reveal the next.',
+			slot: 'photography',
+			tags: ['drag', 'stack']
+		},
+		{
+			id: 'horizontal-rail',
+			title: 'Pinned horizontal story',
+			tagline:
+				'The section pins to the viewport and scrolls sideways as you scroll down — five panels of process, then an exit.',
+			slot: 'about / process',
+			tags: ['scroll pinning', 'parallax']
+		},
+		{
+			id: 'scroll-timeline',
+			title: 'Scroll-driven log',
+			tagline:
+				'Uses native CSS scroll-driven animations where the browser supports them, and falls back to the existing reveal action where it does not.',
+			slot: '2026 page',
+			tags: ['animation-timeline', 'progressive']
+		},
+		{
+			id: 'year-grid',
+			title: 'The year in days',
+			tagline:
+				'365 cells, days elapsed filled, logged moments ringed, today pulsing. Hover for the day.',
+			slot: '2026 page',
+			tags: ['heatmap', 'deterministic']
+		},
+		{
+			id: 'status-orb',
+			title: 'Live status card',
+			tagline:
+				'Melbourne time to the second, real sunrise and sunset from a solar calculation, and a rotating “currently” line.',
+			slot: 'home / about',
+			tags: ['live clock', 'solar math']
+		},
+		{
+			id: 'constellation',
+			title: 'Interest constellation',
+			tagline:
+				'A force-directed map of what connects to what. Nodes repel, links spring, the cursor pushes them around, hovering isolates a neighbourhood.',
+			slot: 'about / colophon',
+			tags: ['canvas', 'force graph']
+		},
+		{
+			id: 'physics-tags',
+			title: 'Physics tag pile',
+			tagline:
+				'Real rigid-body physics via matter-js. Throw the tags around, flip gravity, drop them again.',
+			slot: 'about',
+			tags: ['matter-js', 'ragdoll']
+		},
+		{
+			id: 'marginalia',
+			title: 'Marginalia reader',
+			tagline:
+				'Margin notes pinned to their paragraphs, inline footnotes, a progress ring, and a focus mode that dims everything but the line you are on.',
+			slot: 'writing',
+			tags: ['reading', 'focus mode']
+		},
+		{
+			id: 'reaction-bar',
+			title: 'Reaction bar',
+			tagline:
+				'Tap to react, hold to spray confetti. Cheap feedback that does not need an account.',
+			slot: 'writing / photos',
+			tags: ['particles', 'micro-interaction']
+		},
+		{
+			id: 'theme-studio',
+			title: 'Theme studio',
+			tagline:
+				'Four sliders generate an entire oklch palette and rewrite the live custom properties on <html>. Switch it on and the real header retints.',
+			slot: 'footer / easter egg',
+			tags: ['oklch', 'css vars', 'live']
+		},
+		{
+			id: 'mega-footer',
+			title: 'Mega wordmark footer',
+			tagline:
+				'The name, clipped by the page edge, filled with a photograph, rising into place as you reach the bottom.',
+			slot: 'footer',
+			tags: ['background-clip', 'parallax']
+		}
+	];
+
+	function frame(id: string) {
+		const index = concepts.findIndex((concept) => concept.id === id);
+		return { ...concepts[index], index: index + 1 };
+	}
+
+	let active = $state(concepts[0].id);
+	let scrolled = $state(0);
+
+	onMount(() => {
+		// Scroll spy: the band between 25% and 60% of the viewport decides which
+		// concept the index rail highlights.
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting && entry.target.id) active = entry.target.id;
+				}
+			},
+			{ rootMargin: '-25% 0px -40% 0px', threshold: 0 }
+		);
+
+		for (const concept of concepts) {
+			const el = document.getElementById(concept.id);
+			if (el) observer.observe(el);
+		}
+
+		let raf = 0;
+		function update() {
+			raf = 0;
+			const max = document.documentElement.scrollHeight - window.innerHeight;
+			scrolled = max > 0 ? window.scrollY / max : 0;
+		}
+		function onScroll() {
+			if (!raf) raf = requestAnimationFrame(update);
+		}
+		update();
+		window.addEventListener('scroll', onScroll, { passive: true });
+
+		return () => {
+			observer.disconnect();
+			window.removeEventListener('scroll', onScroll);
+			if (raf) cancelAnimationFrame(raf);
+		};
+	});
+</script>
+
+<svelte:head>
+	<title>Design lab | Matej Groombridge</title>
+	<meta name="robots" content="noindex, nofollow" />
+	<meta name="description" content="A temporary sandbox of design concepts." />
+</svelte:head>
+
+<div class="lab">
+	<div class="page-progress" aria-hidden="true">
+		<span style={`transform:scaleX(${scrolled})`}></span>
+	</div>
+
+	<header class="masthead">
+		<div class="masthead-inner">
+			<span class="lab-chip" data-tone="accent">temporary · /lab</span>
+			<h1 data-preserve-case>Design lab</h1>
+			<p class="blurb">
+				{concepts.length} self-contained concepts for the site — each one live, not a screenshot. Nothing
+				here is wired into the real pages, and the whole thing is one folder to delete. Keep what you
+				like, bin the rest.
+			</p>
+			<p class="blurb small">
+				Try <kbd data-preserve-case>⌘K</kbd> anywhere on this page, and flip the site into dark mode with
+				the header toggle — everything below is built for both.
+			</p>
+		</div>
+	</header>
+
+	<div class="layout">
+		<nav class="rail" aria-label="Concept index">
+			<span class="rail-title lab-mono">index</span>
+			<ol>
+				{#each concepts as concept, i (concept.id)}
+					<li>
+						<a href={`#${concept.id}`} class:on={active === concept.id}>
+							<span class="rail-num lab-mono">{String(i + 1).padStart(2, '0')}</span>
+							<span class="rail-label">{concept.title}</span>
+						</a>
+					</li>
+				{/each}
+			</ol>
+		</nav>
+
+		<div class="stream">
+			<ConceptFrame {...frame('kinetic-masthead')} bleed>
+				<KineticMasthead />
+				{#snippet notes()}
+					<p>
+						One custom property per glyph does all the work, so the browser animates
+						<code>font-variation-settings</code> and nothing else. Falls back to a slow travelling wave
+						when there is no pointer, and to a static weight under reduced motion.
+					</p>
+				{/snippet}
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('aurora-hero')} bleed>
+				<AuroraHero />
+				{#snippet notes()}
+					<p>
+						The canvas is a sixteenth of the pixels it appears to be — a heavy CSS blur turns six
+						cheap radial fills into a gradient mesh. It reads the palette out of the CSS variables,
+						so it retints itself in dark mode and after the theme studio below has been used.
+					</p>
+				{/snippet}
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('command-palette')}>
+				<CommandPalette />
+				{#snippet notes()}
+					<p>
+						The index is built from the same content modules the pages use, so it never goes stale.
+						Scoring rewards matches at word starts and runs of adjacent characters, which is why
+						<code>btr</code> finds <em>Born To Run</em> before anything else.
+					</p>
+				{/snippet}
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('stats-strip')}>
+				<StatsStrip />
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('spotlight-grid')} bleed>
+				<SpotlightGrid />
+				{#snippet notes()}
+					<p>
+						Card rectangles are measured once and cached, so moving the cursor costs one layout read
+						for the whole grid rather than one per card. On touch devices the torch is dropped and
+						the cards settle at a fixed glow.
+					</p>
+				{/snippet}
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('velocity-ticker')} bleed>
+				<VelocityTicker />
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('text-treatments')}>
+				<TextTreatments />
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('elastic-nav')}>
+				<ElasticNav />
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('hover-preview-list')}>
+				<HoverPreviewList />
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('bookshelf')} bleed>
+				<Bookshelf />
+				{#snippet notes()}
+					<p>
+						Each book is one element with three faces in <code>preserve-3d</code>: cover, spine
+						hinged at its left edge, and a sliver of page block. Shelved, you see the spine; hovered
+						or tabbed to, the whole thing swings out.
+					</p>
+				{/snippet}
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('contact-sheet')}>
+				<ContactSheet />
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('photo-deck')}>
+				<PhotoDeck />
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('horizontal-rail')} bare>
+				<HorizontalRail />
+				{#snippet notes()}
+					<p>
+						Vertical scroll distance is mapped straight onto a horizontal transform — no scroll
+						hijacking, so a flick, a trackpad and a scrollbar drag all behave the way the reader
+						expects, and the back button still works.
+					</p>
+				{/snippet}
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('scroll-timeline')}>
+				<ScrollTimeline />
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('year-grid')}>
+				<YearGrid />
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('status-orb')}>
+				<StatusOrb />
+				{#snippet notes()}
+					<p>
+						Sunrise and sunset come from NOAA's approximation evaluated in the browser — accurate to
+						about a minute, with no API call and no date library. The clock only renders after mount
+						so a cached page can never show a stale time.
+					</p>
+				{/snippet}
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('constellation')} bleed>
+				<Constellation />
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('physics-tags')}>
+				<PhysicsTags />
+				{#snippet notes()}
+					<p>
+						The only third-party dependency on this page. If this concept goes, so does
+						<code>matter-js</code> — everything else here is hand-rolled.
+					</p>
+				{/snippet}
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('marginalia')}>
+				<Marginalia />
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('reaction-bar')}>
+				<ReactionBar />
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('theme-studio')}>
+				<ThemeStudio />
+				{#snippet notes()}
+					<p>
+						Inline custom properties on <code>&lt;html&gt;</code> out-specify every stylesheet rule, so
+						switching this on retints the real header and footer too. It cleans up after itself when you
+						navigate away.
+					</p>
+				{/snippet}
+			</ConceptFrame>
+
+			<ConceptFrame {...frame('mega-footer')} bleed>
+				<MegaFooter />
+			</ConceptFrame>
+
+			<p class="tail lab-mono">
+				end of the lab — delete <code>src/routes/lab/</code> to remove it all
+			</p>
+		</div>
+	</div>
+</div>
+
+<style lang="scss">
+	.page-progress {
+		position: fixed;
+		top: 0;
+		left: 0;
+		right: 0;
+		height: 2px;
+		z-index: 60;
+		background: transparent;
+		pointer-events: none;
+	}
+
+	.page-progress span {
+		display: block;
+		height: 100%;
+		background: var(--lab-accent);
+		transform-origin: left center;
+		transform: scaleX(0);
+	}
+
+	.masthead {
+		padding: clamp(2rem, 6vw, 4rem) 0 clamp(1.5rem, 4vw, 2.5rem);
+	}
+
+	.masthead-inner {
+		width: var(--size-page);
+		margin-inline: auto;
+		display: grid;
+		justify-items: start;
+		gap: 0.85rem;
+	}
+
+	h1 {
+		margin: 0;
+		font-family: var(--font-ui);
+		font-size: clamp(2.4rem, 7vw, 4.5rem);
+		font-weight: 700;
+		letter-spacing: -0.05em;
+		line-height: 1;
+	}
+
+	.blurb {
+		max-width: 62ch;
+		margin: 0;
+		color: var(--color-subtle);
+		font-size: clamp(0.95rem, 1.3vw, 1.08rem);
+		line-height: 1.65;
+	}
+
+	.blurb.small {
+		font-size: 0.88rem;
+		opacity: 0.85;
+	}
+
+	kbd {
+		font-family: var(--lab-mono);
+		font-size: 0.72em;
+		padding: 0.16em 0.4em;
+		border: 1px solid var(--lab-hairline);
+		border-bottom-width: 2px;
+		border-radius: var(--radius-sm);
+		background: var(--color-muted);
+	}
+
+	.layout {
+		width: var(--size-page);
+		margin-inline: auto;
+		display: grid;
+		grid-template-columns: var(--lab-rail) minmax(0, 1fr);
+		gap: clamp(1.5rem, 4vw, 3rem);
+		align-items: start;
+		padding-bottom: 4rem;
+	}
+
+	.rail {
+		position: sticky;
+		top: 1.5rem;
+		max-height: calc(100vh - 3rem);
+		overflow-y: auto;
+		padding-right: 0.5rem;
+		scrollbar-width: thin;
+	}
+
+	.rail-title {
+		display: block;
+		margin-bottom: 0.6rem;
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+		opacity: 0.7;
+	}
+
+	.rail ol {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: grid;
+		gap: 1px;
+	}
+
+	.rail a {
+		display: grid;
+		grid-template-columns: 1.6rem minmax(0, 1fr);
+		gap: 0.4rem;
+		align-items: baseline;
+		padding: 0.32rem 0.45rem;
+		border-radius: var(--radius-sm);
+		text-decoration: none;
+		color: var(--color-subtle);
+		transition:
+			background 180ms ease,
+			color 180ms ease;
+	}
+
+	.rail a:hover {
+		background: var(--color-muted);
+		color: var(--color-heading);
+	}
+
+	.rail a.on {
+		background: color-mix(in srgb, var(--lab-accent) 13%, transparent);
+		color: var(--color-heading);
+	}
+
+	.rail-num {
+		font-size: 0.55rem;
+		opacity: 0.75;
+	}
+
+	.rail a.on .rail-num {
+		color: var(--lab-accent);
+		opacity: 1;
+	}
+
+	.rail-label {
+		font-size: 0.8rem;
+		font-weight: 500;
+		line-height: 1.35;
+	}
+
+	.stream {
+		min-width: 0;
+	}
+
+	// The first frame supplies its own top rule via ConceptFrame; suppress it so
+	// the stream does not open with a stray hairline under the masthead.
+	.stream :global(section.frame:first-child) {
+		border-top: none;
+		padding-top: 0;
+	}
+
+	.tail {
+		margin: 3rem 0 0;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--lab-hairline);
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+		opacity: 0.6;
+	}
+
+	.tail code {
+		font-family: var(--lab-mono);
+	}
+
+	@media (max-width: 1000px) {
+		.layout {
+			grid-template-columns: minmax(0, 1fr);
+			gap: 1rem;
+		}
+
+		// The index becomes a sticky horizontal strip once there is no gutter for it.
+		.rail {
+			position: sticky;
+			top: 0;
+			z-index: 30;
+			max-height: none;
+			margin-inline: calc(var(--size-page) / -2 + 50%);
+			padding: 0.5rem 0;
+			background: color-mix(in srgb, var(--color-cream) 92%, transparent);
+			backdrop-filter: blur(10px);
+			border-bottom: 1px solid var(--lab-hairline);
+		}
+
+		.rail-title {
+			display: none;
+		}
+
+		.rail ol {
+			display: flex;
+			gap: 0.25rem;
+			overflow-x: auto;
+			scrollbar-width: none;
+		}
+
+		.rail ol::-webkit-scrollbar {
+			display: none;
+		}
+
+		.rail a {
+			grid-template-columns: auto auto;
+			white-space: nowrap;
+			border: 1px solid var(--lab-hairline);
+			border-radius: 999px;
+			padding: 0.3rem 0.65rem;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/+page.svelte
+++ b/personal-website/src/routes/lab/chrome/+page.svelte
@@ -1,0 +1,571 @@
+<script lang="ts">
+	// ---------------------------------------------------------------------------
+	// TEMPORARY — headers & footers sandbox, sibling to /lab.
+	// Delete `src/routes/lab/` to remove this along with everything else.
+	// ---------------------------------------------------------------------------
+	import { onMount } from 'svelte';
+	import '../lab.scss';
+
+	import ChromeFrame from './ChromeFrame.svelte';
+
+	import H01Rule from './headers/H01Rule.svelte';
+	import H02Dock from './headers/H02Dock.svelte';
+	import H03Masthead from './headers/H03Masthead.svelte';
+	import H04StatusStrip from './headers/H04StatusStrip.svelte';
+	import H05CommandBar from './headers/H05CommandBar.svelte';
+	import H06Index from './headers/H06Index.svelte';
+	import H07Rail from './headers/H07Rail.svelte';
+	import H08Overlay from './headers/H08Overlay.svelte';
+	import H09AutoHide from './headers/H09AutoHide.svelte';
+	import H10PhotoStrip from './headers/H10PhotoStrip.svelte';
+
+	import F01Wordmark from './footers/F01Wordmark.svelte';
+	import F02Postcard from './footers/F02Postcard.svelte';
+	import F03Terminal from './footers/F03Terminal.svelte';
+	import F04Marquee from './footers/F04Marquee.svelte';
+	import F05Colophon from './footers/F05Colophon.svelte';
+	import F06Now from './footers/F06Now.svelte';
+	import F07Reply from './footers/F07Reply.svelte';
+	import F08Place from './footers/F08Place.svelte';
+	import F09PhotoStrip from './footers/F09PhotoStrip.svelte';
+	import F10Signature from './footers/F10Signature.svelte';
+
+	type Meta = {
+		id: string;
+		kind: 'header' | 'footer';
+		title: string;
+		tagline: string;
+		tags: string[];
+	};
+
+	// Single source of truth for the tab strip, the section headers and the
+	// numbering, so nothing drifts as designs are cut.
+	const items: Meta[] = [
+		{
+			id: 'h-rule',
+			kind: 'header',
+			title: 'Rule',
+			tagline:
+				'The quiet default. Condenses on scroll and draws a green rule out from the centre of the active link.',
+			tags: ['sticky', 'condensing']
+		},
+		{
+			id: 'h-dock',
+			kind: 'header',
+			title: 'Floating dock',
+			tagline:
+				'A frosted capsule detached from the top edge, with one indicator pill that travels between items and leans toward whatever you hover.',
+			tags: ['glass', 'single indicator']
+		},
+		{
+			id: 'h-masthead',
+			kind: 'header',
+			title: 'Editorial masthead',
+			tagline:
+				'A newspaper front page: oversized Fraunces wordmark, links set as two numbered columns, and a strapline rule underneath.',
+			tags: ['editorial', 'display type']
+		},
+		{
+			id: 'h-status',
+			kind: 'header',
+			title: 'Status strip',
+			tagline:
+				'A live detail bar that scrolls away, over a nav row that pins. The strip carries the local time and what I am reading.',
+			tags: ['two-tier', 'live']
+		},
+		{
+			id: 'h-command',
+			kind: 'header',
+			title: 'Command bar',
+			tagline:
+				'Nav collapses into a single search affordance. Everything is reachable by typing, so the bar stops competing with the page.',
+			tags: ['⌘K', 'minimal nav']
+		},
+		{
+			id: 'h-index',
+			kind: 'header',
+			title: 'Contents page',
+			tagline:
+				'Links set as a printed table of contents, with dotted leaders and counts. Hovering one entry recedes the rest.',
+			tags: ['toc', 'dimming']
+		},
+		{
+			id: 'h-rail',
+			kind: 'header',
+			title: 'Vertical rail',
+			tagline:
+				'Nav rotated onto a fixed left rail with the monogram at the top and socials at the foot. Lies down into a bar on small screens.',
+			tags: ['vertical', 'fixed']
+		},
+		{
+			id: 'h-overlay',
+			kind: 'header',
+			title: 'Overlay menu',
+			tagline:
+				'Almost nothing until you open it, then a full-bleed sheet of display type with a photograph cross-fading behind the hovered link.',
+			tags: ['full-bleed', 'photo preview']
+		},
+		{
+			id: 'h-autohide',
+			kind: 'header',
+			title: 'Auto-hide',
+			tagline:
+				'Gets out of the way going down, comes back the instant you scroll up, and carries a reading-progress line.',
+			tags: ['scroll direction', 'progress']
+		},
+		{
+			id: 'h-photo',
+			kind: 'header',
+			title: 'Photo dissolve',
+			tagline:
+				'Opens as a strip of the current photograph with white nav over it, then dissolves to paper and ink across the first 160px of scroll.',
+			tags: ['image', 'scroll ramp']
+		},
+
+		{
+			id: 'f-wordmark',
+			kind: 'footer',
+			title: 'Outlined wordmark',
+			tagline:
+				'Link columns over a giant outlined surname. Outlined rather than filled so it holds the bottom of the page without shouting.',
+			tags: ['display type', 'columns']
+		},
+		{
+			id: 'f-postcard',
+			kind: 'footer',
+			title: 'Postcard',
+			tagline:
+				'A photograph, a perforated stamp, a postmark and a handwritten note. The most personal option here by a distance.',
+			tags: ['skeuomorphic', 'caveat']
+		},
+		{
+			id: 'f-terminal',
+			kind: 'footer',
+			title: 'Terminal',
+			tagline:
+				'A shell session that types itself out on load. Links become commands, contact becomes an environment variable.',
+			tags: ['mono', 'typewriter']
+		},
+		{
+			id: 'f-marquee',
+			kind: 'footer',
+			title: 'Marquee band',
+			tagline:
+				'A scrolling call to action across the full width, pausing on hover while the display type loses its softness.',
+			tags: ['marquee', 'variable font']
+		},
+		{
+			id: 'f-colophon',
+			kind: 'footer',
+			title: 'Colophon',
+			tagline:
+				'Type-forward: two paragraphs about how the site is made, next to a spec sheet of what it is made from.',
+			tags: ['long-form', 'spec sheet']
+		},
+		{
+			id: 'f-now',
+			kind: 'footer',
+			title: 'Now',
+			tagline:
+				'Four cards of what is actually happening — reading, building, shooting, training — each on its own hairline of colour.',
+			tags: ['status', 'cards']
+		},
+		{
+			id: 'f-reply',
+			kind: 'footer',
+			title: 'One-field reply',
+			tagline:
+				'A single email field that grows a message box only once you commit to it, then confirms in place.',
+			tags: ['form', 'progressive']
+		},
+		{
+			id: 'f-place',
+			kind: 'footer',
+			title: 'Place',
+			tagline:
+				'Coordinates, live local time, and a drawn location mark — no map embed, no third-party tracking.',
+			tags: ['svg map', 'live clock']
+		},
+		{
+			id: 'f-photos',
+			kind: 'footer',
+			title: 'Photo strip',
+			tagline:
+				'Seven trips as a full-width strip that reallocates its space to whichever frame you hover. A footer that is also a way back in.',
+			tags: ['flex grow', 'imagery']
+		},
+		{
+			id: 'f-signature',
+			kind: 'footer',
+			title: 'Signature',
+			tagline:
+				'The anti-footer: one line, a drawn signature, and an email that slides to reveal its own copy state.',
+			tags: ['minimal', 'one line']
+		}
+	];
+
+	const headers = $derived(items.filter((item) => item.kind === 'header'));
+	const footers = $derived(items.filter((item) => item.kind === 'footer'));
+
+	function meta(id: string) {
+		const index = items.findIndex((item) => item.id === id);
+		const item = items[index];
+		// Headers and footers are numbered 01–10 within their own run.
+		const within = items.filter((other) => other.kind === item.kind).indexOf(item);
+		return { ...item, index: within + 1 };
+	}
+
+	let active = $state(items[0].id);
+
+	onMount(() => {
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (entry.isIntersecting && entry.target.id) active = entry.target.id;
+				}
+			},
+			{ rootMargin: '-20% 0px -55% 0px', threshold: 0 }
+		);
+		for (const item of items) {
+			const el = document.getElementById(item.id);
+			if (el) observer.observe(el);
+		}
+		return () => observer.disconnect();
+	});
+</script>
+
+<svelte:head>
+	<title>Header &amp; footer lab | Matej Groombridge</title>
+	<meta name="robots" content="noindex, nofollow" />
+	<meta name="description" content="A temporary sandbox of header and footer concepts." />
+</svelte:head>
+
+<div class="lab">
+	<header class="masthead">
+		<div class="masthead-inner">
+			<a class="back lab-mono" href="/lab">← back to the concept lab</a>
+			<span class="lab-chip" data-tone="accent">temporary · /lab/chrome</span>
+			<h1 data-preserve-case>Headers &amp; footers</h1>
+			<p class="blurb">
+				Ten of each, live rather than mocked up. Every preview has a width switcher — the chrome is
+				laid out with container queries, so narrowing the frame really does put it into its
+				small-screen layout instead of waiting on your browser window.
+			</p>
+			<p class="blurb small">
+				Headers sit in a scrolling frame so you can see what they do on the way down. Footers are
+				shown at their natural height with a scrap of page above.
+			</p>
+		</div>
+	</header>
+
+	<nav class="tabs" aria-label="Jump to">
+		<div class="tabs-inner">
+			<span class="tabs-label lab-mono">headers</span>
+			{#each headers as item, i (item.id)}
+				<a href={`#${item.id}`} class:on={active === item.id}>
+					<span class="lab-mono">{String(i + 1).padStart(2, '0')}</span>
+					{item.title}
+				</a>
+			{/each}
+			<span class="tabs-label lab-mono">footers</span>
+			{#each footers as item, i (item.id)}
+				<a href={`#${item.id}`} class:on={active === item.id}>
+					<span class="lab-mono">{String(i + 1).padStart(2, '0')}</span>
+					{item.title}
+				</a>
+			{/each}
+		</div>
+	</nav>
+
+	<div class="stream">
+		<h2 class="run-title" id="headers">
+			<span class="run-num lab-mono">A</span> Headers
+		</h2>
+
+		<ChromeFrame {...meta('h-rule')}>
+			<H01Rule />
+			{#snippet notes()}
+				<p>
+					The condense threshold has a gap in it — collapse past 40px, expand below 12px — so a
+					scroll that settles right on the boundary can&rsquo;t make the header flicker.
+				</p>
+			{/snippet}
+		</ChromeFrame>
+
+		<ChromeFrame {...meta('h-dock')}>
+			<H02Dock />
+			{#snippet notes()}
+				<p>
+					Equal-width grid columns mean the indicator travels by whole percentages, so there is no
+					measuring and no resize observer — it just works at any label length.
+				</p>
+			{/snippet}
+		</ChromeFrame>
+
+		<ChromeFrame {...meta('h-masthead')}><H03Masthead /></ChromeFrame>
+
+		<ChromeFrame {...meta('h-status')}><H04StatusStrip /></ChromeFrame>
+
+		<ChromeFrame {...meta('h-command')}>
+			<H05CommandBar />
+			{#snippet notes()}
+				<p>
+					Pairs with the command palette from the main lab page — this is what the header looks like
+					once search is the primary way around the site.
+				</p>
+			{/snippet}
+		</ChromeFrame>
+
+		<ChromeFrame {...meta('h-index')}><H06Index /></ChromeFrame>
+
+		<ChromeFrame {...meta('h-rail')} layout="rail">
+			<H07Rail />
+			{#snippet notes()}
+				<p>
+					Costs about 68px of width for the whole session, which is cheap on a desktop and far too
+					expensive on a phone — so under 560px it lies down into an ordinary bar.
+				</p>
+			{/snippet}
+		</ChromeFrame>
+
+		<ChromeFrame {...meta('h-overlay')}>
+			<H08Overlay />
+			{#snippet notes()}
+				<p>
+					Click <em>menu</em> in the frame. The sheet wipes in and the links stagger up behind it.
+				</p>
+			{/snippet}
+		</ChromeFrame>
+
+		<ChromeFrame {...meta('h-autohide')}>
+			<H09AutoHide />
+			{#snippet notes()}
+				<p>
+					Requires 4px of deliberate movement before it reacts, and never hides in the first 80px,
+					so trackpad jitter can&rsquo;t make it strobe.
+				</p>
+			{/snippet}
+		</ChromeFrame>
+
+		<ChromeFrame {...meta('h-photo')}>
+			<H10PhotoStrip />
+			{#snippet notes()}
+				<p>
+					Scroll position drives a continuous 0→1 ramp rather than flipping a class, so the header
+					dissolves between photograph and paper instead of snapping between two states.
+				</p>
+			{/snippet}
+		</ChromeFrame>
+
+		<h2 class="run-title" id="footers">
+			<span class="run-num lab-mono">B</span> Footers
+		</h2>
+
+		<ChromeFrame {...meta('f-wordmark')}><F01Wordmark /></ChromeFrame>
+
+		<ChromeFrame {...meta('f-postcard')}>
+			<F02Postcard />
+			{#snippet notes()}
+				<p>
+					The stamp perforation is a repeating radial mask rather than an image, so it stays crisp
+					at any size and costs nothing to load.
+				</p>
+			{/snippet}
+		</ChromeFrame>
+
+		<ChromeFrame {...meta('f-terminal')} dark><F03Terminal /></ChromeFrame>
+
+		<ChromeFrame {...meta('f-marquee')} dark><F04Marquee /></ChromeFrame>
+
+		<ChromeFrame {...meta('f-colophon')}><F05Colophon /></ChromeFrame>
+
+		<ChromeFrame {...meta('f-now')}><F06Now /></ChromeFrame>
+
+		<ChromeFrame {...meta('f-reply')}>
+			<F07Reply />
+			{#snippet notes()}
+				<p>
+					Type a valid address in the frame — the send button only lights once the pattern matches,
+					and the message box appears the moment the field takes focus.
+				</p>
+			{/snippet}
+		</ChromeFrame>
+
+		<ChromeFrame {...meta('f-place')}><F08Place /></ChromeFrame>
+
+		<ChromeFrame {...meta('f-photos')} dark>
+			<F09PhotoStrip />
+			{#snippet notes()}
+				<p>
+					The frames are flex items sharing one row, so the hovered one grows by taking space from
+					its neighbours — the strip stays exactly full width the whole time.
+				</p>
+			{/snippet}
+		</ChromeFrame>
+
+		<ChromeFrame {...meta('f-signature')}><F10Signature /></ChromeFrame>
+
+		<p class="tail lab-mono">
+			end of the chrome lab — <a href="/lab">back to the concept lab</a>
+		</p>
+	</div>
+</div>
+
+<style lang="scss">
+	.masthead {
+		padding: clamp(2rem, 5vw, 3.5rem) 0 clamp(1rem, 3vw, 1.75rem);
+	}
+
+	.masthead-inner {
+		width: var(--size-page);
+		margin-inline: auto;
+		display: grid;
+		justify-items: start;
+		gap: 0.7rem;
+	}
+
+	.back {
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+		text-decoration: none;
+	}
+
+	.back:hover {
+		color: var(--lab-accent);
+	}
+
+	h1 {
+		margin: 0;
+		font-family: var(--font-ui);
+		font-size: clamp(2.2rem, 6.5vw, 4rem);
+		font-weight: 700;
+		letter-spacing: -0.05em;
+		line-height: 1;
+	}
+
+	.blurb {
+		max-width: 64ch;
+		margin: 0;
+		color: var(--color-subtle);
+		font-size: clamp(0.95rem, 1.3vw, 1.05rem);
+		line-height: 1.65;
+	}
+
+	.blurb.small {
+		font-size: 0.88rem;
+		opacity: 0.85;
+	}
+
+	.tabs {
+		position: sticky;
+		top: 0;
+		z-index: 30;
+		background: color-mix(in srgb, var(--color-cream) 92%, transparent);
+		backdrop-filter: blur(10px);
+		border-block: 1px solid var(--lab-hairline);
+	}
+
+	.tabs-inner {
+		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		width: var(--size-page);
+		margin-inline: auto;
+		padding: 0.5rem 0;
+		overflow-x: auto;
+		scrollbar-width: none;
+	}
+
+	.tabs-inner::-webkit-scrollbar {
+		display: none;
+	}
+
+	.tabs-label {
+		flex: 0 0 auto;
+		padding: 0 0.5rem 0 0.25rem;
+		font-size: 0.5rem;
+		color: var(--color-subtle);
+		opacity: 0.65;
+	}
+
+	.tabs-label:not(:first-child) {
+		margin-left: 0.5rem;
+		padding-left: 0.85rem;
+		border-left: 1px solid var(--lab-hairline);
+	}
+
+	.tabs a {
+		flex: 0 0 auto;
+		display: inline-flex;
+		align-items: baseline;
+		gap: 0.35rem;
+		padding: 0.3rem 0.6rem;
+		border-radius: 999px;
+		font-family: var(--font-ui);
+		font-size: 0.76rem;
+		font-weight: 500;
+		color: var(--color-subtle);
+		text-decoration: none;
+		white-space: nowrap;
+		transition:
+			background 180ms ease,
+			color 180ms ease;
+	}
+
+	.tabs a span {
+		font-size: 0.5rem;
+		opacity: 0.7;
+	}
+
+	.tabs a:hover {
+		background: var(--color-muted);
+		color: var(--color-heading);
+	}
+
+	.tabs a.on {
+		background: color-mix(in srgb, var(--lab-accent) 14%, transparent);
+		color: var(--color-heading);
+	}
+
+	.tabs a.on span {
+		color: var(--lab-accent);
+		opacity: 1;
+	}
+
+	.stream {
+		width: var(--size-page);
+		margin-inline: auto;
+		padding-bottom: 4rem;
+	}
+
+	.run-title {
+		display: flex;
+		align-items: baseline;
+		gap: 0.7rem;
+		margin: clamp(2rem, 5vw, 3.5rem) 0 0;
+		padding-bottom: 0.5rem;
+		font-family: var(--font-ui);
+		font-size: clamp(1.4rem, 3vw, 2rem);
+		font-weight: 700;
+		letter-spacing: -0.04em;
+		scroll-margin-top: 4rem;
+	}
+
+	.run-num {
+		font-size: 0.7rem;
+		color: var(--lab-accent);
+	}
+
+	.tail {
+		margin: 3rem 0 0;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--lab-hairline);
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+		opacity: 0.7;
+	}
+
+	.tail a {
+		color: var(--lab-accent);
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/ChromeFrame.svelte
+++ b/personal-website/src/routes/lab/chrome/ChromeFrame.svelte
@@ -1,0 +1,343 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	type Props = {
+		id: string;
+		index: number;
+		kind: 'header' | 'footer';
+		title: string;
+		tagline: string;
+		tags?: string[];
+		/** Preview on a dark ground — for chrome that is designed inverted. */
+		dark?: boolean;
+		/** `rail` puts the chrome beside the page content instead of above it. */
+		layout?: 'stack' | 'rail';
+		children: Snippet;
+		notes?: Snippet;
+	};
+
+	let {
+		id,
+		index,
+		kind,
+		title,
+		tagline,
+		tags = [],
+		dark = false,
+		layout = 'stack',
+		children,
+		notes
+	}: Props = $props();
+
+	const widths = [
+		{ label: 'desktop', value: 0 },
+		{ label: 'tablet', value: 820 },
+		{ label: 'phone', value: 390 }
+	];
+	let width = $state(0);
+
+	const number = $derived(String(index).padStart(2, '0'));
+</script>
+
+<section class="frame" {id} aria-labelledby={`${id}-title`}>
+	<header class="head">
+		<div class="head-main">
+			<span class="number lab-mono" aria-hidden="true">{number}</span>
+			<div class="head-text">
+				<h3 id={`${id}-title`} data-preserve-case>{title}</h3>
+				<p class="tagline">{tagline}</p>
+			</div>
+		</div>
+
+		<div class="controls">
+			<div class="widths" role="group" aria-label="Preview width">
+				{#each widths as option (option.label)}
+					<button
+						class="width-btn lab-mono"
+						class:on={width === option.value}
+						type="button"
+						onclick={() => (width = option.value)}
+					>
+						{option.label}
+					</button>
+				{/each}
+			</div>
+			{#each tags as tag (tag)}
+				<span class="lab-chip">{tag}</span>
+			{/each}
+		</div>
+	</header>
+
+	<!--
+		`container-type: inline-size` is what makes the width switcher honest: the
+		chrome components below lay themselves out with `@container` queries, so
+		narrowing this box really does put them into their small-screen layout.
+		Media queries would only ever see the real browser window.
+	-->
+	<div class="stage" class:dark style={width ? `max-width:${width}px` : ''}>
+		{#if kind === 'header'}
+			<div class="viewport" class:rail={layout === 'rail'}>
+				{@render children()}
+				<div class="filler">
+					<div class="filler-hero">
+						<span class="lab-mono filler-eyebrow">photography</span>
+						<h4>Sydney, March</h4>
+						<p>Three days of walking the harbour with one lens, mostly at the wrong time of day.</p>
+					</div>
+					{#each [0, 1, 2, 3, 4, 5] as row (row)}
+						<div class="filler-row">
+							<span class="bar" style={`width:${[92, 74, 88, 61, 80, 70][row]}%`}></span>
+							<span class="bar short" style={`width:${[48, 62, 38, 55, 44, 58][row]}%`}></span>
+						</div>
+					{/each}
+				</div>
+			</div>
+			<p class="scroll-hint lab-mono">scroll inside the frame ↕</p>
+		{:else}
+			<div class="footer-stage">
+				<div class="filler tail">
+					<div class="filler-row">
+						<span class="bar" style="width:86%"></span>
+						<span class="bar short" style="width:52%"></span>
+					</div>
+				</div>
+				{@render children()}
+			</div>
+		{/if}
+	</div>
+
+	{#if notes}
+		<footer class="notes">
+			<span class="notes-label lab-mono">why</span>
+			<div class="notes-body">{@render notes()}</div>
+		</footer>
+	{/if}
+</section>
+
+<style lang="scss">
+	.frame {
+		scroll-margin-top: 5rem;
+		padding-block: clamp(2rem, 4vw, 3.25rem);
+		border-top: 1px solid var(--lab-hairline);
+	}
+
+	.head {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 0.85rem;
+		margin-bottom: 1.1rem;
+	}
+
+	.head-main {
+		display: flex;
+		align-items: baseline;
+		gap: 0.9rem;
+		min-width: 0;
+	}
+
+	.number {
+		flex: 0 0 auto;
+		font-size: 0.72rem;
+		font-weight: 700;
+		color: var(--lab-accent);
+		font-variant-numeric: tabular-nums;
+	}
+
+	h3 {
+		margin: 0;
+		font-family: var(--font-ui);
+		font-size: clamp(1.15rem, 1.9vw, 1.45rem);
+		font-weight: 700;
+		letter-spacing: -0.03em;
+	}
+
+	.tagline {
+		margin: 0.28rem 0 0;
+		max-width: 60ch;
+		color: var(--color-subtle);
+		font-size: 0.9rem;
+		line-height: 1.55;
+	}
+
+	.controls {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.35rem;
+	}
+
+	.widths {
+		display: inline-flex;
+		gap: 1px;
+		padding: 2px;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 999px;
+		background: var(--color-muted);
+	}
+
+	.width-btn {
+		padding: 0.22rem 0.55rem;
+		border: none;
+		border-radius: 999px;
+		background: none;
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+		transition:
+			background 180ms ease,
+			color 180ms ease;
+	}
+
+	.width-btn.on {
+		background: var(--color-surface);
+		color: var(--color-heading);
+		box-shadow: var(--shadow-subtle);
+	}
+
+	.stage {
+		container-type: inline-size;
+		margin-inline: auto;
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-lg);
+		background: var(--color-cream);
+		overflow: hidden;
+		transition: max-width 320ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	// Some chrome is designed to sit on ink rather than paper; this lets a
+	// preview declare that without every component shipping its own backdrop.
+	.stage.dark {
+		background: #141615;
+		color: #e9ece7;
+	}
+
+	.viewport {
+		--viewport-h: 440px;
+		position: relative;
+		height: var(--viewport-h);
+		overflow-y: auto;
+		overscroll-behavior: contain;
+		scrollbar-width: thin;
+	}
+
+	// A rail sits alongside the page rather than on top of it, so the scroll
+	// container becomes a row and the chrome pins itself to the left of it.
+	.viewport.rail {
+		display: flex;
+		align-items: flex-start;
+	}
+
+	.viewport.rail .filler {
+		flex: 1;
+		min-width: 0;
+	}
+
+	.footer-stage {
+		display: grid;
+	}
+
+	.filler {
+		display: grid;
+		gap: 1.1rem;
+		padding: 1.5rem clamp(1rem, 4cqw, 2.5rem) 3rem;
+	}
+
+	.filler.tail {
+		padding-block: 1.75rem 2rem;
+	}
+
+	.filler-hero {
+		display: grid;
+		gap: 0.35rem;
+		padding-bottom: 0.5rem;
+	}
+
+	.filler-eyebrow {
+		font-size: 0.55rem;
+		color: var(--lab-accent);
+	}
+
+	.filler-hero h4 {
+		margin: 0;
+		font-family: var(--font-display);
+		font-size: clamp(1.5rem, 4cqw, 2.2rem);
+		font-weight: 500;
+		letter-spacing: -0.03em;
+		color: var(--color-heading);
+	}
+
+	.filler-hero p {
+		margin: 0;
+		max-width: 46ch;
+		font-size: 0.9rem;
+		color: var(--color-subtle);
+	}
+
+	.filler-row {
+		display: grid;
+		gap: 0.5rem;
+	}
+
+	// Greeked body copy: the point of the preview is the chrome, and real
+	// paragraphs would pull the eye away from it.
+	.bar {
+		display: block;
+		height: 8px;
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--color-ink) 8%, transparent);
+	}
+
+	.bar.short {
+		height: 8px;
+		opacity: 0.6;
+	}
+
+	.stage.dark .bar {
+		background: rgb(255 255 255 / 0.09);
+	}
+
+	.scroll-hint {
+		margin: 0.5rem 0 0;
+		padding: 0 0.75rem 0.6rem;
+		font-size: 0.52rem;
+		color: var(--color-subtle);
+		opacity: 0.55;
+		text-align: center;
+	}
+
+	.notes {
+		display: flex;
+		gap: 0.85rem;
+		margin-top: 1rem;
+	}
+
+	.notes-label {
+		flex: 0 0 auto;
+		padding-top: 0.2rem;
+		font-size: 0.6rem;
+		color: var(--lab-accent);
+	}
+
+	.notes-body {
+		max-width: 70ch;
+		color: var(--color-subtle);
+		font-size: 0.86rem;
+		line-height: 1.6;
+	}
+
+	.notes-body :global(p) {
+		margin: 0;
+		font-size: inherit;
+		line-height: inherit;
+		color: inherit;
+	}
+
+	.notes-body :global(code) {
+		font-family: var(--lab-mono);
+		font-size: 0.85em;
+		padding: 0.1em 0.35em;
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--color-ink) 8%, transparent);
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/footers/F01Wordmark.svelte
+++ b/personal-website/src/routes/lab/chrome/footers/F01Wordmark.svelte
@@ -1,0 +1,157 @@
+<script lang="ts">
+	const columns = [
+		{ label: 'Look', links: ['Photography', 'Trips', 'Gear'] },
+		{ label: 'Read', links: ['Book notes', 'Writing', 'Now'] },
+		{ label: 'Find me', links: ['Instagram', 'GitHub', 'LinkedIn'] }
+	];
+</script>
+
+<footer class="foot">
+	<div class="top">
+		{#each columns as column (column.label)}
+			<div class="col">
+				<span class="col-label lab-mono">{column.label}</span>
+				<ul>
+					{#each column.links as link (link)}
+						<li><a href="/">{link}</a></li>
+					{/each}
+				</ul>
+			</div>
+		{/each}
+
+		<div class="col say">
+			<span class="col-label lab-mono">say hello</span>
+			<a class="mail" href="/" data-preserve-case>matejdpg@gmail.com</a>
+			<p>Usually a reply within a day, unless I am somewhere with no signal.</p>
+		</div>
+	</div>
+
+	<!-- Outlined rather than filled: at this size a solid wordmark would out-shout
+	     everything above it, where an outline just holds the bottom of the page. -->
+	<div class="wordmark" aria-hidden="true">Groombridge</div>
+
+	<div class="base lab-mono">
+		<span>© 2026 matej groombridge</span>
+		<span>built in melbourne · sveltekit</span>
+	</div>
+</footer>
+
+<style lang="scss">
+	.foot {
+		container-type: inline-size;
+		display: grid;
+		gap: clamp(1.25rem, 4cqw, 2.5rem);
+		padding: clamp(1.75rem, 5cqw, 3rem) clamp(1rem, 4cqw, 2.5rem) 0;
+		background: var(--color-cream);
+		border-top: 1px solid var(--lab-hairline);
+		overflow: hidden;
+	}
+
+	.top {
+		display: grid;
+		grid-template-columns: repeat(3, auto) minmax(180px, 1fr);
+		gap: clamp(1rem, 3cqw, 2.5rem);
+	}
+
+	.col-label {
+		display: block;
+		margin-bottom: 0.6rem;
+		font-size: 0.5rem;
+		color: var(--lab-accent);
+	}
+
+	ul {
+		display: grid;
+		gap: 0.3rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.col a {
+		font-family: var(--font-ui);
+		font-size: 0.84rem;
+		font-weight: 500;
+		color: var(--color-subtle);
+		text-decoration: none;
+		transition: color 180ms ease;
+	}
+
+	.col a:hover {
+		color: var(--color-heading);
+	}
+
+	.say {
+		justify-self: end;
+		text-align: right;
+	}
+
+	.mail {
+		display: inline-block;
+		font-family: var(--font-ui);
+		font-size: 0.95rem;
+		font-weight: 600;
+		color: var(--color-heading);
+		text-decoration: none;
+		border-bottom: 1.5px solid var(--lab-accent);
+	}
+
+	.say p {
+		margin: 0.5rem 0 0;
+		max-width: 26ch;
+		margin-left: auto;
+		font-size: 0.78rem;
+		line-height: 1.5;
+		color: var(--color-subtle);
+	}
+
+	.wordmark {
+		margin-inline: -0.02em;
+		font-family: var(--font-ui);
+		// Sized so the eleven characters of the surname fit at any container
+		// width. Kept well under the measured limit because Poppins at weight
+		// 800 sets appreciably wider than the fallback it is measured against.
+		font-size: 14cqw;
+		font-weight: 800;
+		line-height: 0.8;
+		letter-spacing: -0.045em;
+		text-align: center;
+		white-space: nowrap;
+		color: transparent;
+		-webkit-text-stroke: 1.5px color-mix(in srgb, var(--color-ink) 26%, transparent);
+		user-select: none;
+	}
+
+	.base {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		gap: 0.35rem 1.5rem;
+		padding: 0.75rem 0 1rem;
+		font-size: 0.52rem;
+		color: var(--color-subtle);
+	}
+
+	@container (max-width: 720px) {
+		.top {
+			grid-template-columns: repeat(3, 1fr);
+		}
+
+		.say {
+			grid-column: 1 / -1;
+			justify-self: start;
+			text-align: left;
+		}
+
+		.say p {
+			margin-left: 0;
+		}
+	}
+
+	@container (max-width: 440px) {
+		.top {
+			grid-template-columns: repeat(2, 1fr);
+			gap: 1.25rem;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/footers/F02Postcard.svelte
+++ b/personal-website/src/routes/lab/chrome/footers/F02Postcard.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+	import { photoTrips } from '$lib/content';
+
+	const trip = photoTrips[0];
+	const stamp = trip?.coverImage ?? '';
+</script>
+
+<footer class="foot">
+	<div class="card">
+		<div class="left">
+			<img src={trip?.coverImage} alt="" loading="lazy" />
+			<span class="caption lab-mono">{trip?.title} · {trip?.year}</span>
+		</div>
+
+		<div class="right">
+			<div class="postmark" aria-hidden="true">
+				<span class="stamp" style={`background-image:url(${stamp})`}></span>
+				<span class="rings">
+					<span class="ring-text lab-mono">melbourne · vic 3000</span>
+				</span>
+			</div>
+
+			<p class="note">
+				Thanks for reading all the way down here. If any of it was useful — or you just want to
+				argue about a book — write back.
+			</p>
+
+			<div class="address">
+				<span class="to lab-mono">reply to</span>
+				<a class="mail" href="/" data-preserve-case>matejdpg@gmail.com</a>
+				<div class="lines" aria-hidden="true"><i></i><i></i><i></i></div>
+			</div>
+
+			<ul class="socials lab-mono">
+				<li><a href="/">instagram</a></li>
+				<li><a href="/">github</a></li>
+				<li><a href="/">linkedin</a></li>
+			</ul>
+		</div>
+	</div>
+
+	<div class="base lab-mono">
+		<span>© 2026</span>
+		<span>no newsletter, no popups</span>
+	</div>
+</footer>
+
+<style lang="scss">
+	.foot {
+		container-type: inline-size;
+		padding: clamp(1.5rem, 4cqw, 2.75rem) clamp(1rem, 4cqw, 2.5rem);
+		background: var(--color-muted);
+		border-top: 1px solid var(--lab-hairline);
+	}
+
+	.card {
+		display: grid;
+		grid-template-columns: minmax(0, 0.85fr) minmax(0, 1fr);
+		gap: 0;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 3px;
+		background: var(--color-surface);
+		box-shadow: 0 14px 34px -22px rgb(0 0 0 / 0.5);
+		overflow: hidden;
+	}
+
+	.left {
+		position: relative;
+		min-height: 180px;
+	}
+
+	.left img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	.caption {
+		position: absolute;
+		left: 0.6rem;
+		bottom: 0.6rem;
+		padding: 0.16rem 0.4rem;
+		border-radius: 2px;
+		background: rgb(0 0 0 / 0.55);
+		font-size: 0.5rem;
+		color: #fff;
+	}
+
+	.right {
+		position: relative;
+		display: grid;
+		align-content: start;
+		gap: 0.85rem;
+		padding: clamp(1rem, 3cqw, 1.6rem);
+		// The vertical rule down the middle of a real postcard.
+		border-left: 1px dashed var(--lab-hairline);
+	}
+
+	.postmark {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		gap: 0.6rem;
+	}
+
+	.stamp {
+		width: 46px;
+		height: 56px;
+		background-size: cover;
+		background-position: center 40%;
+		// Perforated stamp edge, cut with a repeating radial mask. The tile is
+		// deliberately coarse — at 6px the teeth turned the whole stamp to lace.
+		-webkit-mask-image: radial-gradient(circle at 4.5px 4.5px, transparent 2.6px, #000 2.9px);
+		mask-image: radial-gradient(circle at 4.5px 4.5px, transparent 2.6px, #000 2.9px);
+		-webkit-mask-size: 9px 9px;
+		mask-size: 9px 9px;
+		border: 2px solid var(--color-surface);
+		outline: 1px solid var(--lab-hairline);
+	}
+
+	.rings {
+		display: grid;
+		place-items: center;
+		width: 52px;
+		height: 52px;
+		border: 1.5px solid color-mix(in srgb, var(--lab-accent) 60%, transparent);
+		border-radius: 999px;
+		transform: rotate(-12deg);
+		opacity: 0.75;
+	}
+
+	.ring-text {
+		width: 42px;
+		font-size: 0.36rem;
+		line-height: 1.25;
+		text-align: center;
+		color: var(--lab-accent);
+	}
+
+	.note {
+		margin: 0;
+		max-width: 34ch;
+		font-family: 'Caveat', var(--font-body), cursive;
+		font-size: clamp(1.05rem, 2.6cqw, 1.35rem);
+		line-height: 1.35;
+		color: var(--color-heading);
+		text-transform: none;
+	}
+
+	.address {
+		display: grid;
+		gap: 0.25rem;
+	}
+
+	.to {
+		font-size: 0.48rem;
+		color: var(--color-subtle);
+	}
+
+	.mail {
+		font-family: var(--font-ui);
+		font-size: 0.9rem;
+		font-weight: 600;
+		color: var(--color-heading);
+		text-decoration: none;
+		justify-self: start;
+		border-bottom: 1.5px solid var(--lab-accent);
+	}
+
+	.lines {
+		display: grid;
+		gap: 0.42rem;
+		margin-top: 0.5rem;
+	}
+
+	.lines i {
+		display: block;
+		height: 1px;
+		background: var(--lab-hairline);
+	}
+
+	.lines i:nth-child(2) {
+		width: 82%;
+	}
+
+	.lines i:nth-child(3) {
+		width: 60%;
+	}
+
+	.socials {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+		font-size: 0.5rem;
+	}
+
+	.socials a {
+		color: var(--color-subtle);
+		text-decoration: none;
+	}
+
+	.socials a:hover {
+		color: var(--lab-accent);
+	}
+
+	.base {
+		display: flex;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-top: 0.85rem;
+		font-size: 0.5rem;
+		color: var(--color-subtle);
+	}
+
+	@container (max-width: 600px) {
+		.card {
+			grid-template-columns: 1fr;
+		}
+
+		.left {
+			min-height: 130px;
+		}
+
+		.right {
+			border-left: none;
+			border-top: 1px dashed var(--lab-hairline);
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/footers/F03Terminal.svelte
+++ b/personal-website/src/routes/lab/chrome/footers/F03Terminal.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	const lines = [
+		{ cmd: 'whoami', out: 'matej groombridge — photographer, software engineer' },
+		{ cmd: 'ls ~/site', out: 'photography/  booknotes/  writing/  2026/  contact/' },
+		{ cmd: 'cat now.txt', out: 'reading Thinking, Fast and Slow · rebuilding this site' },
+		{ cmd: 'echo $EMAIL', out: 'matejdpg@gmail.com' }
+	];
+
+	// Lines type themselves in on mount rather than being animated by CSS, so
+	// the shell reads as a session replaying instead of a static screenshot.
+	let revealed = $state(0);
+
+	onMount(() => {
+		const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+		if (reduce) {
+			revealed = lines.length;
+			return;
+		}
+		const id = setInterval(() => {
+			revealed += 1;
+			if (revealed >= lines.length) clearInterval(id);
+		}, 420);
+		revealed = 1;
+		return () => clearInterval(id);
+	});
+</script>
+
+<footer class="foot">
+	<div class="shell">
+		<div class="chrome" aria-hidden="true">
+			<span class="dots"><i></i><i></i><i></i></span>
+			<span class="title lab-mono">matej@melbourne — ~/site</span>
+		</div>
+
+		<div class="body lab-mono">
+			{#each lines as line, i (line.cmd)}
+				{#if i < revealed}
+					<p class="cmd"><span class="prompt">$</span> {line.cmd}</p>
+					<p class="out">{line.out}</p>
+				{/if}
+			{/each}
+			<p class="cmd"><span class="prompt">$</span><span class="caret" aria-hidden="true"></span></p>
+		</div>
+	</div>
+
+	<div class="base lab-mono">
+		<a href="/">instagram</a>
+		<a href="/">github</a>
+		<a href="/">linkedin</a>
+		<span class="spacer"></span>
+		<span>© 2026 · exit 0</span>
+	</div>
+</footer>
+
+<style lang="scss">
+	.foot {
+		container-type: inline-size;
+		padding: clamp(1.5rem, 4cqw, 2.75rem) clamp(1rem, 4cqw, 2.5rem);
+		background: #0e1110;
+		color: #d7ded8;
+	}
+
+	.shell {
+		border: 1px solid rgb(255 255 255 / 0.12);
+		border-radius: var(--radius-md);
+		background: #141917;
+		overflow: hidden;
+	}
+
+	.chrome {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		padding: 0.45rem 0.7rem;
+		background: rgb(255 255 255 / 0.05);
+		border-bottom: 1px solid rgb(255 255 255 / 0.08);
+	}
+
+	.dots {
+		display: flex;
+		gap: 5px;
+	}
+
+	.dots i {
+		width: 9px;
+		height: 9px;
+		border-radius: 999px;
+		background: rgb(255 255 255 / 0.18);
+	}
+
+	.dots i:first-child {
+		background: var(--color-green);
+	}
+
+	.title {
+		font-size: 0.5rem;
+		color: rgb(215 222 216 / 0.5);
+	}
+
+	.body {
+		display: grid;
+		gap: 0.1rem;
+		padding: clamp(0.85rem, 3cqw, 1.35rem);
+		font-size: clamp(0.62rem, 1.6cqw, 0.75rem);
+		letter-spacing: 0;
+		text-transform: none;
+	}
+
+	.body p {
+		margin: 0;
+		font-size: inherit;
+		line-height: 1.75;
+		color: inherit;
+		word-break: break-word;
+	}
+
+	.cmd {
+		color: #eef2ec;
+	}
+
+	.prompt {
+		margin-right: 0.5rem;
+		color: var(--color-green);
+	}
+
+	.out {
+		margin-bottom: 0.5rem !important;
+		color: rgb(215 222 216 / 0.62);
+	}
+
+	.caret {
+		display: inline-block;
+		width: 7px;
+		height: 1em;
+		vertical-align: text-bottom;
+		background: var(--color-green);
+		animation: blink 1.1s steps(1) infinite;
+	}
+
+	@keyframes blink {
+		50% {
+			opacity: 0;
+		}
+	}
+
+	.base {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.5rem 1.1rem;
+		margin-top: 1rem;
+		font-size: 0.52rem;
+		color: rgb(215 222 216 / 0.45);
+	}
+
+	.base a {
+		color: rgb(215 222 216 / 0.7);
+		text-decoration: none;
+	}
+
+	.base a:hover {
+		color: var(--color-green);
+	}
+
+	.spacer {
+		flex: 1;
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/footers/F04Marquee.svelte
+++ b/personal-website/src/routes/lab/chrome/footers/F04Marquee.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+	const links = ['Photography', 'Book notes', 'Writing', '2026', 'Contact'];
+	const phrase = 'get in touch';
+</script>
+
+<footer class="foot">
+	<!-- Pure CSS loop: two identical tracks, the pair translated by exactly half
+	     their combined width, so the seam never lands inside the viewport. -->
+	<a class="band" href="/" aria-label="Get in touch">
+		<div class="track">
+			{#each [0, 1] as copy (copy)}
+				<span class="run" aria-hidden={copy === 1}>
+					{#each [0, 1, 2, 3] as item (item)}
+						<span class="word" data-preserve-case>{phrase}</span>
+						<span class="sep" aria-hidden="true">✳</span>
+					{/each}
+				</span>
+			{/each}
+		</div>
+	</a>
+
+	<div class="rows">
+		<nav aria-label="Footer">
+			<ul>
+				{#each links as link (link)}
+					<li><a href="/">{link}</a></li>
+				{/each}
+			</ul>
+		</nav>
+
+		<div class="meta lab-mono">
+			<span>melbourne, australia</span>
+			<span>© 2026</span>
+		</div>
+	</div>
+</footer>
+
+<style lang="scss">
+	.foot {
+		container-type: inline-size;
+		background: var(--color-heading);
+		color: var(--color-cream);
+		overflow: hidden;
+	}
+
+	.band {
+		display: block;
+		padding: clamp(0.75rem, 2.5cqw, 1.4rem) 0;
+		border-bottom: 1px solid rgb(255 255 255 / 0.12);
+		text-decoration: none;
+		color: inherit;
+		overflow: hidden;
+	}
+
+	.track {
+		display: flex;
+		width: max-content;
+		animation: slide 26s linear infinite;
+	}
+
+	.band:hover .track {
+		animation-play-state: paused;
+	}
+
+	@keyframes slide {
+		to {
+			transform: translateX(-50%);
+		}
+	}
+
+	.run {
+		display: flex;
+		align-items: center;
+		gap: 1.5rem;
+		padding-right: 1.5rem;
+	}
+
+	.word {
+		font-family: var(--font-display);
+		font-size: clamp(1.5rem, 6cqw, 3rem);
+		font-weight: 500;
+		letter-spacing: -0.03em;
+		white-space: nowrap;
+		font-variation-settings: 'SOFT' 60;
+		transition: font-variation-settings 400ms ease;
+	}
+
+	.band:hover .word {
+		font-variation-settings: 'SOFT' 0;
+	}
+
+	.sep {
+		font-size: clamp(0.7rem, 2cqw, 1.1rem);
+		color: var(--color-green);
+	}
+
+	.rows {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.75rem 1.5rem;
+		padding: clamp(0.85rem, 3cqw, 1.4rem) clamp(1rem, 4cqw, 2.5rem);
+	}
+
+	ul {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem 1.25rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	nav a {
+		font-family: var(--font-ui);
+		font-size: 0.84rem;
+		font-weight: 500;
+		color: color-mix(in srgb, var(--color-cream) 72%, transparent);
+		text-decoration: none;
+		transition: color 180ms ease;
+	}
+
+	nav a:hover {
+		color: var(--color-cream);
+	}
+
+	.meta {
+		display: flex;
+		gap: 1.25rem;
+		font-size: 0.52rem;
+		color: color-mix(in srgb, var(--color-cream) 45%, transparent);
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/footers/F05Colophon.svelte
+++ b/personal-website/src/routes/lab/chrome/footers/F05Colophon.svelte
@@ -1,0 +1,167 @@
+<script lang="ts">
+	const facts = [
+		{ k: 'type', v: 'Poppins, Figtree, Fraunces' },
+		{ k: 'built with', v: 'SvelteKit, SCSS, stubbornness' },
+		{ k: 'hosted on', v: 'Netlify' },
+		{ k: 'camera', v: 'Sony α6700 · 35mm' },
+		{ k: 'last touched', v: '18 August 2026' }
+	];
+</script>
+
+<footer class="foot">
+	<div class="grid">
+		<div class="prose">
+			<span class="label lab-mono">colophon</span>
+			<p>
+				This site is written by hand, in a text editor, on a laptop that is usually somewhere it
+				should not be. There is no CMS and no analytics dashboard I actually look at — just a folder
+				of markdown and a folder of photographs, both of which grow slowly.
+			</p>
+			<p>
+				Everything here is a work in progress, including the person who made it. If something is
+				broken, it is probably because I changed it five minutes ago.
+			</p>
+		</div>
+
+		<dl class="facts">
+			{#each facts as fact (fact.k)}
+				<div class="fact">
+					<dt class="lab-mono">{fact.k}</dt>
+					<dd data-preserve-case>{fact.v}</dd>
+				</div>
+			{/each}
+		</dl>
+	</div>
+
+	<div class="base">
+		<nav aria-label="Footer">
+			<ul>
+				<li><a href="/">Photography</a></li>
+				<li><a href="/">Book notes</a></li>
+				<li><a href="/">Writing</a></li>
+				<li><a href="/">Contact</a></li>
+			</ul>
+		</nav>
+		<span class="lab-mono copy">© 2026 matej groombridge</span>
+	</div>
+</footer>
+
+<style lang="scss">
+	.foot {
+		container-type: inline-size;
+		padding: clamp(1.75rem, 5cqw, 3rem) clamp(1rem, 4cqw, 2.5rem) 1.25rem;
+		background: var(--color-cream);
+		border-top: 2px solid var(--color-heading);
+	}
+
+	.grid {
+		display: grid;
+		grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+		gap: clamp(1.25rem, 5cqw, 4rem);
+		align-items: start;
+	}
+
+	.label {
+		display: block;
+		margin-bottom: 0.7rem;
+		font-size: 0.5rem;
+		color: var(--lab-accent);
+	}
+
+	.prose p {
+		margin: 0 0 0.75rem;
+		max-width: 54ch;
+		font-family: var(--font-display);
+		font-size: clamp(0.92rem, 2cqw, 1.02rem);
+		font-weight: 400;
+		line-height: 1.72;
+		color: var(--color-ink);
+		font-variation-settings:
+			'SOFT' 25,
+			'opsz' 14;
+	}
+
+	.prose p:last-child {
+		margin-bottom: 0;
+		color: var(--color-subtle);
+	}
+
+	.facts {
+		display: grid;
+		gap: 0;
+		margin: 0;
+	}
+
+	// Each fact is its own hairline row, so the block reads as a spec sheet
+	// sitting alongside the prose rather than a second paragraph.
+	.fact {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		padding: 0.5rem 0;
+		border-bottom: 1px solid var(--lab-hairline);
+	}
+
+	.fact:first-child {
+		border-top: 1px solid var(--lab-hairline);
+	}
+
+	dt {
+		flex: 0 0 auto;
+		font-size: 0.5rem;
+		color: var(--color-subtle);
+	}
+
+	dd {
+		margin: 0;
+		font-size: 0.8rem;
+		font-weight: 500;
+		color: var(--color-heading);
+		text-align: right;
+	}
+
+	.base {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.6rem 1.5rem;
+		margin-top: clamp(1.25rem, 4cqw, 2.25rem);
+		padding-top: 0.85rem;
+		border-top: 1px solid var(--lab-hairline);
+	}
+
+	ul {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem 1.1rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	nav a {
+		font-family: var(--font-ui);
+		font-size: 0.8rem;
+		font-weight: 500;
+		color: var(--color-subtle);
+		text-decoration: none;
+	}
+
+	nav a:hover {
+		color: var(--lab-accent);
+	}
+
+	.copy {
+		font-size: 0.5rem;
+		color: var(--color-subtle);
+	}
+
+	@container (max-width: 640px) {
+		.grid {
+			grid-template-columns: 1fr;
+			gap: 1.5rem;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/footers/F06Now.svelte
+++ b/personal-website/src/routes/lab/chrome/footers/F06Now.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+	const now = [
+		{ label: 'reading', value: 'Thinking, Fast and Slow', tint: 'a' },
+		{ label: 'building', value: 'this site, again', tint: 'b' },
+		{ label: 'shooting', value: 'Sony α6700 · 35mm', tint: 'c' },
+		{ label: 'training for', value: 'a half, slowly', tint: 'd' }
+	];
+</script>
+
+<footer class="foot">
+	<div class="head">
+		<span class="label lab-mono"><i class="pip"></i> now</span>
+		<span class="stamp lab-mono">updated 3 days ago</span>
+	</div>
+
+	<ul class="cards">
+		{#each now as item (item.label)}
+			<li class={`card tint-${item.tint}`}>
+				<span class="k lab-mono">{item.label}</span>
+				<span class="v" data-preserve-case>{item.value}</span>
+			</li>
+		{/each}
+	</ul>
+
+	<div class="base">
+		<p>
+			This is what I am actually doing, not what I would like you to think I am doing.
+			<a href="/">Full log →</a>
+		</p>
+		<div class="links lab-mono">
+			<a href="/">photos</a>
+			<a href="/">books</a>
+			<a href="/">contact</a>
+		</div>
+	</div>
+</footer>
+
+<style lang="scss">
+	.foot {
+		container-type: inline-size;
+		display: grid;
+		gap: 0.9rem;
+		padding: clamp(1.5rem, 4cqw, 2.5rem) clamp(1rem, 4cqw, 2.5rem);
+		background: var(--color-muted);
+		border-top: 1px solid var(--lab-hairline);
+	}
+
+	.head {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+	}
+
+	.label {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		font-size: 0.55rem;
+		color: var(--color-heading);
+	}
+
+	.pip {
+		width: 6px;
+		height: 6px;
+		border-radius: 999px;
+		background: var(--lab-accent);
+		box-shadow: 0 0 0 0 color-mix(in srgb, var(--lab-accent) 55%, transparent);
+		animation: ping 2.4s ease-out infinite;
+	}
+
+	@keyframes ping {
+		70%,
+		100% {
+			box-shadow: 0 0 0 7px transparent;
+		}
+	}
+
+	.stamp {
+		font-size: 0.5rem;
+		color: var(--color-subtle);
+	}
+
+	.cards {
+		display: grid;
+		grid-template-columns: repeat(4, minmax(0, 1fr));
+		gap: 0.5rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.card {
+		display: grid;
+		gap: 0.25rem;
+		padding: 0.75rem 0.85rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-md);
+		background: var(--color-surface);
+		// A hairline of colour on the leading edge distinguishes the four
+		// strands without turning the row into four different coloured boxes.
+		border-left-width: 3px;
+		transition: transform 240ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	.card:hover {
+		transform: translateY(-3px);
+	}
+
+	.tint-a {
+		border-left-color: var(--lab-accent);
+	}
+	.tint-b {
+		border-left-color: #6d8fd6;
+	}
+	.tint-c {
+		border-left-color: #d6a24c;
+	}
+	.tint-d {
+		border-left-color: #c47a9b;
+	}
+
+	.k {
+		font-size: 0.48rem;
+		color: var(--color-subtle);
+	}
+
+	.v {
+		font-family: var(--font-ui);
+		font-size: 0.85rem;
+		font-weight: 600;
+		line-height: 1.3;
+		color: var(--color-heading);
+	}
+
+	.base {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.6rem 1.5rem;
+		padding-top: 0.6rem;
+		border-top: 1px solid var(--lab-hairline);
+	}
+
+	.base p {
+		margin: 0;
+		max-width: 52ch;
+		font-size: 0.8rem;
+		color: var(--color-subtle);
+	}
+
+	.base p a {
+		color: var(--lab-accent);
+		font-weight: 600;
+		text-decoration: none;
+		white-space: nowrap;
+	}
+
+	.links {
+		display: flex;
+		gap: 0.9rem;
+		font-size: 0.52rem;
+	}
+
+	.links a {
+		color: var(--color-subtle);
+		text-decoration: none;
+	}
+
+	.links a:hover {
+		color: var(--color-heading);
+	}
+
+	@container (max-width: 720px) {
+		.cards {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+
+	@container (max-width: 400px) {
+		.cards {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/footers/F07Reply.svelte
+++ b/personal-website/src/routes/lab/chrome/footers/F07Reply.svelte
@@ -1,0 +1,296 @@
+<script lang="ts">
+	// A one-field footer form: the ask is small enough that a full contact form
+	// would be the reason nobody fills it in.
+	let email = $state('');
+	let message = $state('');
+	let sent = $state(false);
+	let expanded = $state(false);
+
+	const valid = $derived(/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email.trim()));
+
+	function submit(event: SubmitEvent) {
+		event.preventDefault();
+		if (!valid) return;
+		sent = true;
+	}
+</script>
+
+<footer class="foot">
+	<div class="grid">
+		<div class="pitch">
+			<h4>Want to talk?</h4>
+			<p>
+				Commissions, corrections, or a book you think I would like. One field to start — the rest
+				only if you need it.
+			</p>
+		</div>
+
+		{#if sent}
+			<div class="done" role="status">
+				<span class="tick" aria-hidden="true">✓</span>
+				<div>
+					<strong data-preserve-case>Got it.</strong>
+					<span>I&rsquo;ll reply to {email} shortly.</span>
+				</div>
+			</div>
+		{:else}
+			<form onsubmit={submit}>
+				<div class="field">
+					<input
+						type="email"
+						bind:value={email}
+						onfocus={() => (expanded = true)}
+						placeholder="you@example.com"
+						aria-label="Your email"
+						autocomplete="email"
+						required
+					/>
+					<button type="submit" disabled={!valid} aria-label="Send">
+						<span class="arrow" aria-hidden="true">→</span>
+					</button>
+				</div>
+
+				<!-- The message box only appears once the visitor has committed to
+				     the first field, so the footer starts as one small ask. -->
+				{#if expanded}
+					<textarea
+						bind:value={message}
+						rows="2"
+						placeholder="Anything else? (optional)"
+						aria-label="Message"
+					></textarea>
+				{/if}
+
+				<span class="hint lab-mono">
+					{valid ? 'looks good — hit enter' : 'no list, no newsletter, no follow-up sequence'}
+				</span>
+			</form>
+		{/if}
+	</div>
+
+	<div class="base">
+		<nav aria-label="Footer">
+			<ul>
+				<li><a href="/">Photography</a></li>
+				<li><a href="/">Book notes</a></li>
+				<li><a href="/">Writing</a></li>
+				<li><a href="/">2026</a></li>
+			</ul>
+		</nav>
+		<span class="lab-mono copy">© 2026 · melbourne</span>
+	</div>
+</footer>
+
+<style lang="scss">
+	.foot {
+		container-type: inline-size;
+		padding: clamp(1.75rem, 5cqw, 3rem) clamp(1rem, 4cqw, 2.5rem) 1.1rem;
+		background: var(--color-cream);
+		border-top: 1px solid var(--lab-hairline);
+	}
+
+	.grid {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
+		gap: clamp(1.25rem, 4cqw, 3rem);
+		align-items: center;
+	}
+
+	h4 {
+		margin: 0 0 0.4rem;
+		font-family: var(--font-display);
+		font-size: clamp(1.4rem, 4cqw, 2.1rem);
+		font-weight: 500;
+		letter-spacing: -0.03em;
+		color: var(--color-heading);
+		font-variation-settings: 'SOFT' 45;
+	}
+
+	.pitch p {
+		margin: 0;
+		max-width: 38ch;
+		font-size: 0.88rem;
+		line-height: 1.6;
+		color: var(--color-subtle);
+	}
+
+	form {
+		display: grid;
+		gap: 0.5rem;
+	}
+
+	.field {
+		display: flex;
+		align-items: center;
+		gap: 0.35rem;
+		padding: 0.3rem 0.3rem 0.3rem 0.9rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 999px;
+		background: var(--color-surface);
+		transition:
+			border-color 200ms ease,
+			box-shadow 200ms ease;
+	}
+
+	.field:focus-within {
+		border-color: var(--lab-accent);
+		box-shadow: 0 0 0 4px color-mix(in srgb, var(--lab-accent) 12%, transparent);
+	}
+
+	input,
+	textarea {
+		flex: 1;
+		min-width: 0;
+		border: none;
+		background: none;
+		outline: none;
+		font-size: 0.9rem;
+		color: var(--color-heading);
+	}
+
+	input::placeholder,
+	textarea::placeholder {
+		color: color-mix(in srgb, var(--color-subtle) 70%, transparent);
+	}
+
+	textarea {
+		padding: 0.7rem 0.9rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-md);
+		background: var(--color-surface);
+		resize: vertical;
+		font-family: inherit;
+		line-height: 1.5;
+		animation: grow 260ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	@keyframes grow {
+		from {
+			opacity: 0;
+			transform: translateY(-6px);
+		}
+	}
+
+	button {
+		display: grid;
+		place-items: center;
+		width: 2.2rem;
+		height: 2.2rem;
+		border: none;
+		border-radius: 999px;
+		background: var(--color-heading);
+		color: var(--color-cream);
+		transition:
+			background 200ms ease,
+			transform 200ms cubic-bezier(0.2, 0.9, 0.3, 1.4),
+			opacity 200ms ease;
+	}
+
+	button:disabled {
+		opacity: 0.32;
+		cursor: not-allowed;
+	}
+
+	button:not(:disabled) {
+		background: var(--lab-accent);
+	}
+
+	button:not(:disabled):hover {
+		transform: translateX(2px) scale(1.05);
+	}
+
+	.arrow {
+		font-size: 0.95rem;
+		line-height: 1;
+	}
+
+	.hint {
+		padding-left: 0.9rem;
+		font-size: 0.5rem;
+		color: var(--color-subtle);
+	}
+
+	.done {
+		display: flex;
+		align-items: center;
+		gap: 0.75rem;
+		padding: 0.9rem 1.1rem;
+		border: 1px solid color-mix(in srgb, var(--lab-accent) 45%, transparent);
+		border-radius: var(--radius-lg);
+		background: color-mix(in srgb, var(--lab-accent) 10%, transparent);
+		animation: grow 300ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	.tick {
+		display: grid;
+		place-items: center;
+		width: 1.7rem;
+		height: 1.7rem;
+		flex: 0 0 auto;
+		border-radius: 999px;
+		background: var(--lab-accent);
+		color: #fff;
+		font-size: 0.85rem;
+	}
+
+	.done div {
+		display: grid;
+		gap: 0.1rem;
+	}
+
+	.done strong {
+		font-family: var(--font-ui);
+		font-size: 0.9rem;
+		color: var(--color-heading);
+	}
+
+	.done span {
+		font-size: 0.78rem;
+		color: var(--color-subtle);
+		word-break: break-word;
+	}
+
+	.base {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.6rem 1.5rem;
+		margin-top: clamp(1.25rem, 4cqw, 2.25rem);
+		padding-top: 0.85rem;
+		border-top: 1px solid var(--lab-hairline);
+	}
+
+	ul {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem 1.1rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	nav a {
+		font-family: var(--font-ui);
+		font-size: 0.8rem;
+		font-weight: 500;
+		color: var(--color-subtle);
+		text-decoration: none;
+	}
+
+	nav a:hover {
+		color: var(--lab-accent);
+	}
+
+	.copy {
+		font-size: 0.5rem;
+		color: var(--color-subtle);
+	}
+
+	@container (max-width: 640px) {
+		.grid {
+			grid-template-columns: 1fr;
+			gap: 1.1rem;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/footers/F08Place.svelte
+++ b/personal-website/src/routes/lab/chrome/footers/F08Place.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	let time = $state('--:--');
+
+	onMount(() => {
+		const tick = () =>
+			(time = new Intl.DateTimeFormat('en-AU', {
+				timeZone: 'Australia/Melbourne',
+				hour: '2-digit',
+				minute: '2-digit',
+				hour12: false
+			}).format(new Date()));
+		tick();
+		const id = setInterval(tick, 20_000);
+		return () => clearInterval(id);
+	});
+</script>
+
+<footer class="foot">
+	<div class="grid">
+		<div class="place">
+			<span class="label lab-mono">based in</span>
+			<h4 data-preserve-case>Melbourne</h4>
+			<div class="readout lab-mono">
+				<span>37.8136° S</span>
+				<span>144.9631° E</span>
+				<span class="time"><i></i>{time} aedt</span>
+			</div>
+			<p>Available for work that involves a camera, a keyboard, or ideally both.</p>
+		</div>
+
+		<!-- A drawn location mark rather than a map tile: no third-party embed,
+		     no tracking, and it retints with the theme. -->
+		<div class="map" aria-hidden="true">
+			<svg viewBox="0 0 200 140" preserveAspectRatio="xMidYMid slice">
+				<defs>
+					<pattern id="place-grid" width="16" height="16" patternUnits="userSpaceOnUse">
+						<path
+							d="M16 0H0V16"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="0.5"
+							opacity="0.4"
+						/>
+					</pattern>
+				</defs>
+				<rect width="200" height="140" fill="url(#place-grid)" />
+				<path
+					d="M-10 96 C 40 84, 62 104, 96 92 S 160 74, 212 88"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="1.2"
+					opacity="0.55"
+				/>
+				<path
+					d="M-10 112 C 46 102, 70 118, 104 108 S 168 92, 212 104"
+					fill="none"
+					stroke="currentColor"
+					stroke-width="1"
+					opacity="0.3"
+				/>
+				<g class="pin">
+					<circle cx="100" cy="62" r="22" class="halo" />
+					<circle cx="100" cy="62" r="12" class="halo two" />
+					<circle cx="100" cy="62" r="4.5" class="dot" />
+				</g>
+			</svg>
+		</div>
+	</div>
+
+	<div class="base">
+		<nav aria-label="Footer">
+			<ul>
+				<li><a href="/">Photography</a></li>
+				<li><a href="/">Book notes</a></li>
+				<li><a href="/">Writing</a></li>
+				<li><a href="/">Contact</a></li>
+			</ul>
+		</nav>
+		<span class="lab-mono copy">© 2026 matej groombridge</span>
+	</div>
+</footer>
+
+<style lang="scss">
+	.foot {
+		container-type: inline-size;
+		padding: clamp(1.5rem, 4cqw, 2.5rem) clamp(1rem, 4cqw, 2.5rem) 1.1rem;
+		background: var(--color-cream);
+		border-top: 1px solid var(--lab-hairline);
+	}
+
+	.grid {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) minmax(0, 0.85fr);
+		gap: clamp(1.25rem, 4cqw, 3rem);
+		align-items: center;
+	}
+
+	.label {
+		display: block;
+		margin-bottom: 0.3rem;
+		font-size: 0.5rem;
+		color: var(--lab-accent);
+	}
+
+	h4 {
+		margin: 0 0 0.5rem;
+		font-family: var(--font-display);
+		font-size: clamp(1.6rem, 5cqw, 2.6rem);
+		font-weight: 500;
+		letter-spacing: -0.035em;
+		color: var(--color-heading);
+		font-variation-settings: 'SOFT' 45;
+	}
+
+	.readout {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.3rem 1rem;
+		padding-bottom: 0.7rem;
+		border-bottom: 1px solid var(--lab-hairline);
+		font-size: 0.52rem;
+		color: var(--color-subtle);
+	}
+
+	.time {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		color: var(--color-heading);
+	}
+
+	.time i {
+		width: 5px;
+		height: 5px;
+		border-radius: 999px;
+		background: var(--lab-accent);
+	}
+
+	.place p {
+		margin: 0.7rem 0 0;
+		max-width: 34ch;
+		font-size: 0.85rem;
+		line-height: 1.6;
+		color: var(--color-subtle);
+	}
+
+	.map {
+		height: clamp(120px, 22cqw, 170px);
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-md);
+		background: var(--color-muted);
+		color: var(--color-subtle);
+		overflow: hidden;
+	}
+
+	.map svg {
+		width: 100%;
+		height: 100%;
+	}
+
+	.halo {
+		fill: var(--lab-accent);
+		opacity: 0.12;
+		transform-origin: 100px 62px;
+		animation: pulse 3.4s ease-out infinite;
+	}
+
+	.halo.two {
+		opacity: 0.22;
+		animation-delay: 0.5s;
+	}
+
+	.dot {
+		fill: var(--lab-accent);
+	}
+
+	@keyframes pulse {
+		0% {
+			transform: scale(0.6);
+			opacity: 0.3;
+		}
+		100% {
+			transform: scale(1.35);
+			opacity: 0;
+		}
+	}
+
+	.base {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 0.6rem 1.5rem;
+		margin-top: clamp(1.1rem, 3cqw, 1.75rem);
+		padding-top: 0.85rem;
+		border-top: 1px solid var(--lab-hairline);
+	}
+
+	ul {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem 1.1rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	nav a {
+		font-family: var(--font-ui);
+		font-size: 0.8rem;
+		font-weight: 500;
+		color: var(--color-subtle);
+		text-decoration: none;
+	}
+
+	nav a:hover {
+		color: var(--lab-accent);
+	}
+
+	.copy {
+		font-size: 0.5rem;
+		color: var(--color-subtle);
+	}
+
+	@container (max-width: 620px) {
+		.grid {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/footers/F09PhotoStrip.svelte
+++ b/personal-website/src/routes/lab/chrome/footers/F09PhotoStrip.svelte
@@ -1,0 +1,231 @@
+<script lang="ts">
+	import { photoTrips } from '$lib/content';
+
+	// One frame per trip, newest first — the footer doubles as a way back into
+	// the galleries rather than being a dead end.
+	const frames = photoTrips.slice(0, 7).map((trip) => ({
+		slug: trip.slug,
+		title: trip.title,
+		year: trip.year,
+		image: trip.coverImage
+	}));
+
+	let hovered = $state<number | null>(null);
+</script>
+
+<footer class="foot">
+	<ul class="strip" onmouseleave={() => (hovered = null)}>
+		{#each frames as frame, i (frame.slug)}
+			<li>
+				<a
+					class="frame"
+					class:on={hovered === i}
+					href="/"
+					style={`--i:${i}`}
+					onmouseenter={() => (hovered = i)}
+					onfocus={() => (hovered = i)}
+					aria-label={`${frame.title}, ${frame.year}`}
+				>
+					<img src={frame.image} alt="" loading="lazy" />
+					<span class="cap lab-mono">
+						<b data-preserve-case>{frame.title}</b>
+						<i>{frame.year}</i>
+					</span>
+				</a>
+			</li>
+		{/each}
+	</ul>
+
+	<div class="under">
+		<div class="say">
+			<span class="label lab-mono">seven trips, one lens</span>
+			<a class="cta" href="/">
+				See all the photographs
+				<span aria-hidden="true">→</span>
+			</a>
+		</div>
+
+		<nav aria-label="Footer">
+			<ul>
+				<li><a href="/">Book notes</a></li>
+				<li><a href="/">Writing</a></li>
+				<li><a href="/">2026</a></li>
+				<li><a href="/">Contact</a></li>
+			</ul>
+		</nav>
+	</div>
+
+	<div class="base lab-mono">
+		<span>© 2026 matej groombridge</span>
+		<span>all photographs my own</span>
+	</div>
+</footer>
+
+<style lang="scss">
+	.foot {
+		container-type: inline-size;
+		background: var(--color-heading);
+		color: var(--color-cream);
+	}
+
+	// Flex with a grown basis on hover: the hovered frame takes the space and
+	// its neighbours give it up, so the strip stays exactly full width.
+	.strip {
+		display: flex;
+		height: clamp(110px, 20cqw, 180px);
+		margin: 0;
+		padding: 0;
+		list-style: none;
+		overflow: hidden;
+	}
+
+	.strip li {
+		display: flex;
+		flex: 1 1 0;
+		min-width: 0;
+		border-right: 1px solid rgb(0 0 0 / 0.35);
+		transition: flex-grow 480ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	.strip li:last-child {
+		border-right: none;
+	}
+
+	.strip li:has(.frame.on) {
+		flex-grow: 2.4;
+	}
+
+	.frame {
+		position: relative;
+		flex: 1;
+		min-width: 0;
+		overflow: hidden;
+		text-decoration: none;
+		color: inherit;
+	}
+
+	.frame img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		filter: grayscale(0.65) brightness(0.72);
+		transform: scale(1.04);
+		transition:
+			filter 480ms ease,
+			transform 700ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	.frame.on img {
+		filter: grayscale(0) brightness(0.92);
+		transform: scale(1);
+	}
+
+	.cap {
+		position: absolute;
+		left: 0.55rem;
+		bottom: 0.5rem;
+		right: 0.55rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.05rem;
+		font-size: 0.5rem;
+		opacity: 0;
+		transform: translateY(6px);
+		transition:
+			opacity 320ms ease,
+			transform 320ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	.frame.on .cap {
+		opacity: 1;
+		transform: none;
+	}
+
+	.cap b {
+		font-family: var(--font-ui);
+		font-size: 0.8rem;
+		font-weight: 600;
+		letter-spacing: -0.02em;
+		white-space: nowrap;
+	}
+
+	.cap i {
+		font-style: normal;
+		color: var(--color-green);
+	}
+
+	.under {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem 1.5rem;
+		padding: clamp(1.1rem, 3cqw, 1.75rem) clamp(1rem, 4cqw, 2.5rem) 0.85rem;
+	}
+
+	.label {
+		display: block;
+		margin-bottom: 0.25rem;
+		font-size: 0.5rem;
+		color: color-mix(in srgb, var(--color-cream) 50%, transparent);
+	}
+
+	.cta {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		font-family: var(--font-display);
+		font-size: clamp(1.15rem, 3cqw, 1.7rem);
+		font-weight: 500;
+		letter-spacing: -0.03em;
+		color: var(--color-cream);
+		text-decoration: none;
+		font-variation-settings: 'SOFT' 45;
+	}
+
+	.cta span {
+		transition: transform 260ms cubic-bezier(0.2, 0.9, 0.3, 1.3);
+	}
+
+	.cta:hover span {
+		transform: translateX(6px);
+	}
+
+	ul {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem 1.1rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	nav a {
+		font-family: var(--font-ui);
+		font-size: 0.82rem;
+		font-weight: 500;
+		color: color-mix(in srgb, var(--color-cream) 70%, transparent);
+		text-decoration: none;
+	}
+
+	nav a:hover {
+		color: var(--color-green);
+	}
+
+	.base {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		gap: 0.3rem 1.5rem;
+		padding: 0 clamp(1rem, 4cqw, 2.5rem) 1rem;
+		font-size: 0.5rem;
+		color: color-mix(in srgb, var(--color-cream) 40%, transparent);
+	}
+
+	@container (max-width: 620px) {
+		// Seven slivers are unreadable on a phone; drop to four wider frames.
+		.strip li:nth-child(n + 5) {
+			display: none;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/footers/F10Signature.svelte
+++ b/personal-website/src/routes/lab/chrome/footers/F10Signature.svelte
@@ -1,0 +1,180 @@
+<script lang="ts">
+	// The anti-footer: one line. Everything optional has been removed, so what
+	// is left has to be worth the space it takes.
+	let copied = $state(false);
+
+	async function copy() {
+		try {
+			await navigator.clipboard.writeText('matejdpg@gmail.com');
+			copied = true;
+			setTimeout(() => (copied = false), 1600);
+		} catch {
+			copied = false;
+		}
+	}
+</script>
+
+<footer class="foot">
+	<div class="line">
+		<span class="sig" aria-hidden="true">
+			<svg viewBox="0 0 120 46" fill="none">
+				<path
+					d="M6 36 C 12 10, 18 8, 21 22 S 26 40, 32 24 S 40 6, 44 26 C 47 40, 54 34, 58 24 C 63 12, 70 14, 72 26 C 74 36, 80 36, 86 28 C 92 20, 98 22, 100 30 C 102 37, 108 34, 114 24"
+					stroke="currentColor"
+					stroke-width="2.4"
+					stroke-linecap="round"
+					stroke-linejoin="round"
+				/>
+			</svg>
+		</span>
+
+		<button class="mail" type="button" onclick={copy}>
+			<span class="mail-inner">
+				<span class="mail-text" data-preserve-case>matejdpg@gmail.com</span>
+				<span class="mail-state lab-mono">{copied ? 'copied' : 'click to copy'}</span>
+			</span>
+		</button>
+
+		<nav aria-label="Footer">
+			<ul class="lab-mono">
+				<li><a href="/">photos</a></li>
+				<li><a href="/">books</a></li>
+				<li><a href="/">writing</a></li>
+			</ul>
+		</nav>
+
+		<span class="year lab-mono">2026</span>
+	</div>
+</footer>
+
+<style lang="scss">
+	.foot {
+		container-type: inline-size;
+		padding: clamp(1.75rem, 5cqw, 3rem) clamp(1rem, 4cqw, 2.5rem);
+		background: var(--color-cream);
+		border-top: 1px solid var(--lab-hairline);
+	}
+
+	.line {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: clamp(0.85rem, 3cqw, 2rem);
+	}
+
+	.sig {
+		flex: 0 0 auto;
+		width: clamp(72px, 12cqw, 104px);
+		color: var(--color-heading);
+	}
+
+	.sig svg {
+		width: 100%;
+		height: auto;
+	}
+
+	// The stroke draws itself the first time the footer is painted, which is
+	// the entire ornament budget for this design.
+	.sig path {
+		stroke-dasharray: 420;
+		stroke-dashoffset: 420;
+		animation: sign 1.6s cubic-bezier(0.5, 0, 0.2, 1) 200ms forwards;
+	}
+
+	@keyframes sign {
+		to {
+			stroke-dashoffset: 0;
+		}
+	}
+
+	.mail {
+		flex: 0 1 auto;
+		min-width: 0;
+		padding: 0;
+		border: none;
+		background: none;
+		text-align: left;
+	}
+
+	// Two lines stacked in a clipped box; the button slides between them on
+	// hover so the label and its state never both take up room.
+	.mail-inner {
+		display: block;
+		height: 1.35em;
+		overflow: hidden;
+	}
+
+	.mail-text,
+	.mail-state {
+		display: block;
+		height: 1.35em;
+		line-height: 1.35em;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		transition: transform 320ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	.mail-text {
+		font-family: var(--font-ui);
+		font-size: clamp(0.85rem, 2.4cqw, 1.05rem);
+		font-weight: 600;
+		letter-spacing: -0.02em;
+		color: var(--color-heading);
+	}
+
+	.mail-state {
+		font-size: 0.55rem;
+		color: var(--lab-accent);
+	}
+
+	.mail:hover .mail-text,
+	.mail:hover .mail-state,
+	.mail:focus-visible .mail-text,
+	.mail:focus-visible .mail-state {
+		transform: translateY(-1.35em);
+	}
+
+	ul {
+		display: flex;
+		gap: clamp(0.6rem, 2cqw, 1.25rem);
+		margin: 0;
+		padding: 0;
+		list-style: none;
+		font-size: 0.55rem;
+	}
+
+	nav a {
+		color: var(--color-subtle);
+		text-decoration: none;
+		transition: color 180ms ease;
+	}
+
+	nav a:hover {
+		color: var(--color-heading);
+	}
+
+	.year {
+		flex: 0 0 auto;
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+		opacity: 0.6;
+	}
+
+	@container (max-width: 600px) {
+		.line {
+			flex-wrap: wrap;
+			justify-content: flex-start;
+			gap: 0.85rem 1.25rem;
+		}
+
+		.sig {
+			order: -1;
+			flex-basis: 100%;
+		}
+
+		.year {
+			margin-left: auto;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/headers/H01Rule.svelte
+++ b/personal-website/src/routes/lab/chrome/headers/H01Rule.svelte
@@ -1,0 +1,147 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { onFrameScroll, scrollHost } from '../scrollHost';
+
+	const links = ['Photos', 'Book notes', 'Writing', '2026', 'Contact'];
+	let active = $state(0);
+
+	let el = $state<HTMLElement>();
+	let condensed = $state(false);
+
+	onMount(() => {
+		if (!el) return;
+		// Condense past 40px and expand again below 12px — the gap stops the
+		// header flickering when a scroll settles right on the threshold.
+		return onFrameScroll(scrollHost(el), (top) => {
+			if (top > 40) condensed = true;
+			else if (top < 12) condensed = false;
+		});
+	});
+</script>
+
+<header class="bar" class:condensed bind:this={el}>
+	<a class="brand" href="/" data-preserve-case>Matej Groombridge</a>
+
+	<nav aria-label="Primary">
+		<ul>
+			{#each links as link, i (link)}
+				<li>
+					<a
+						href="/"
+						class:on={active === i}
+						aria-current={active === i ? 'page' : undefined}
+						onclick={(event) => {
+							event.preventDefault();
+							active = i;
+						}}
+					>
+						{link}
+					</a>
+				</li>
+			{/each}
+		</ul>
+	</nav>
+</header>
+
+<style lang="scss">
+	.bar {
+		position: sticky;
+		top: 0;
+		z-index: 5;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1.5rem;
+		padding: 1.5rem clamp(1rem, 4cqw, 2.5rem);
+		background: color-mix(in srgb, var(--color-cream) 86%, transparent);
+		backdrop-filter: blur(12px);
+		border-bottom: 1px solid transparent;
+		transition:
+			padding 320ms cubic-bezier(0.2, 0.9, 0.3, 1),
+			border-color 320ms ease;
+	}
+
+	.bar.condensed {
+		padding-block: 0.7rem;
+		border-bottom-color: var(--lab-hairline);
+	}
+
+	.brand {
+		font-family: var(--font-ui);
+		font-size: 1.05rem;
+		font-weight: 700;
+		letter-spacing: -0.04em;
+		color: var(--color-heading);
+		text-decoration: none;
+		white-space: nowrap;
+		transition: font-size 320ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	.bar.condensed .brand {
+		font-size: 0.92rem;
+	}
+
+	ul {
+		display: flex;
+		gap: clamp(0.75rem, 2.5cqw, 1.6rem);
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	nav a {
+		position: relative;
+		display: block;
+		padding-block: 0.3rem;
+		font-family: var(--font-ui);
+		font-size: 0.85rem;
+		font-weight: 500;
+		color: var(--color-subtle);
+		text-decoration: none;
+		white-space: nowrap;
+		transition: color 200ms ease;
+	}
+
+	nav a:hover,
+	nav a.on {
+		color: var(--color-heading);
+	}
+
+	// The rule grows from the centre out, so it reads as being drawn rather
+	// than sliding in from one side.
+	nav a::after {
+		content: '';
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		height: 2px;
+		border-radius: 999px;
+		background: var(--lab-accent);
+		transform: scaleX(0);
+		transition: transform 260ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	nav a:hover::after {
+		transform: scaleX(0.45);
+	}
+
+	nav a.on::after {
+		transform: scaleX(1);
+	}
+
+	@container (max-width: 640px) {
+		.bar {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 0.75rem;
+			padding-block: 1rem;
+		}
+
+		ul {
+			width: 100%;
+			overflow-x: auto;
+			scrollbar-width: none;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/headers/H02Dock.svelte
+++ b/personal-website/src/routes/lab/chrome/headers/H02Dock.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+	const links = ['Photos', 'Books', 'Writing', '2026', 'Contact'];
+	let active = $state(0);
+	let hovered = $state<number | null>(null);
+
+	// The indicator is a single element that travels between items, so the
+	// dock reads as one object rather than five independently lit buttons.
+	const lit = $derived(hovered ?? active);
+</script>
+
+<div class="wrap">
+	<header class="dock">
+		<a class="brand" href="/" aria-label="Home" data-preserve-case>MG</a>
+
+		<nav aria-label="Primary" onmouseleave={() => (hovered = null)}>
+			<ul style={`--lit:${lit}; --count:${links.length}`}>
+				<span class="pill" aria-hidden="true"></span>
+				{#each links as link, i (link)}
+					<li>
+						<a
+							href="/"
+							class:on={active === i}
+							onmouseenter={() => (hovered = i)}
+							onfocus={() => (hovered = i)}
+							onclick={(event) => {
+								event.preventDefault();
+								active = i;
+							}}
+						>
+							{link}
+						</a>
+					</li>
+				{/each}
+			</ul>
+		</nav>
+
+		<button class="orb" type="button" aria-label="Toggle theme"><span></span></button>
+	</header>
+</div>
+
+<style lang="scss">
+	.wrap {
+		position: sticky;
+		top: 0;
+		z-index: 5;
+		display: flex;
+		justify-content: center;
+		padding: 0.85rem clamp(0.75rem, 3cqw, 1.5rem);
+		pointer-events: none;
+	}
+
+	.dock {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		max-width: 100%;
+		padding: 0.35rem 0.35rem 0.35rem 0.85rem;
+		border: 1px solid color-mix(in srgb, var(--color-ink) 10%, transparent);
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--color-surface) 72%, transparent);
+		backdrop-filter: blur(18px) saturate(1.4);
+		box-shadow:
+			0 1px 0 rgb(255 255 255 / 0.5) inset,
+			0 10px 30px -12px rgb(0 0 0 / 0.28);
+		pointer-events: auto;
+	}
+
+	.brand {
+		font-family: var(--font-ui);
+		font-size: 0.85rem;
+		font-weight: 800;
+		letter-spacing: -0.02em;
+		color: var(--color-heading);
+		text-decoration: none;
+	}
+
+	ul {
+		position: relative;
+		display: grid;
+		grid-auto-flow: column;
+		grid-auto-columns: 1fr;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	// One pill, positioned by index. Equal-width columns mean its travel is a
+	// pure percentage — no measuring, no resize observer.
+	.pill {
+		position: absolute;
+		top: 0;
+		bottom: 0;
+		left: 0;
+		width: calc(100% / var(--count));
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--lab-accent) 15%, transparent);
+		transform: translateX(calc(var(--lit) * 100%));
+		transition: transform 380ms cubic-bezier(0.3, 1.4, 0.4, 1);
+	}
+
+	nav a {
+		position: relative;
+		display: block;
+		padding: 0.5rem 0.85rem;
+		font-family: var(--font-ui);
+		font-size: 0.82rem;
+		font-weight: 550;
+		text-align: center;
+		color: var(--color-subtle);
+		text-decoration: none;
+		white-space: nowrap;
+		transition: color 200ms ease;
+	}
+
+	nav a:hover,
+	nav a.on {
+		color: var(--color-heading);
+	}
+
+	.orb {
+		display: grid;
+		place-items: center;
+		width: 2rem;
+		height: 2rem;
+		border: none;
+		border-radius: 999px;
+		background: var(--color-muted);
+	}
+
+	.orb span {
+		width: 12px;
+		height: 12px;
+		border-radius: 999px;
+		background: linear-gradient(140deg, var(--lab-accent), var(--color-heading));
+	}
+
+	@container (max-width: 640px) {
+		.dock {
+			width: 100%;
+			justify-content: space-between;
+		}
+
+		nav a {
+			padding-inline: 0.5rem;
+			font-size: 0.74rem;
+		}
+	}
+
+	@container (max-width: 430px) {
+		// Below this the five labels stop fitting, so the dock keeps the brand
+		// and control and lets the nav itself scroll.
+		nav {
+			min-width: 0;
+			overflow-x: auto;
+			scrollbar-width: none;
+		}
+
+		ul {
+			grid-auto-columns: max-content;
+		}
+
+		.pill {
+			display: none;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/headers/H03Masthead.svelte
+++ b/personal-website/src/routes/lab/chrome/headers/H03Masthead.svelte
@@ -1,0 +1,160 @@
+<script lang="ts">
+	const primary = ['Photography', 'Book notes', 'Writing'];
+	const secondary = ['2026', 'About', 'Contact'];
+</script>
+
+<header class="masthead">
+	<div class="top">
+		<a class="wordmark" href="/" data-preserve-case>Matej<br />Groombridge</a>
+
+		<div class="cols">
+			<nav aria-label="Primary">
+				<span class="col-label lab-mono">the work</span>
+				<ul>
+					{#each primary as link, i (link)}
+						<li>
+							<a href="/">
+								<span class="idx lab-mono">{String(i + 1).padStart(2, '0')}</span>
+								<span class="label">{link}</span>
+							</a>
+						</li>
+					{/each}
+				</ul>
+			</nav>
+
+			<nav aria-label="Secondary">
+				<span class="col-label lab-mono">the person</span>
+				<ul>
+					{#each secondary as link, i (link)}
+						<li>
+							<a href="/">
+								<span class="idx lab-mono">{String(i + 4).padStart(2, '0')}</span>
+								<span class="label">{link}</span>
+							</a>
+						</li>
+					{/each}
+				</ul>
+			</nav>
+		</div>
+	</div>
+
+	<div class="strap lab-mono">
+		<span>photographer &amp; software engineer</span>
+		<span>melbourne, australia</span>
+		<span>est. 2019</span>
+	</div>
+</header>
+
+<style lang="scss">
+	.masthead {
+		padding: clamp(1.5rem, 4cqw, 2.75rem) clamp(1rem, 4cqw, 2.5rem) 0;
+		border-bottom: 2px solid var(--color-heading);
+		background: var(--color-cream);
+	}
+
+	.top {
+		display: flex;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: clamp(1rem, 4cqw, 3rem);
+	}
+
+	.wordmark {
+		font-family: var(--font-display);
+		font-size: clamp(1.6rem, 6cqw, 3.1rem);
+		font-weight: 600;
+		line-height: 0.94;
+		letter-spacing: -0.035em;
+		color: var(--color-heading);
+		text-decoration: none;
+		font-variation-settings:
+			'SOFT' 40,
+			'opsz' 120;
+	}
+
+	.cols {
+		display: flex;
+		gap: clamp(1.25rem, 4cqw, 3rem);
+	}
+
+	.col-label {
+		display: block;
+		margin-bottom: 0.55rem;
+		padding-bottom: 0.3rem;
+		border-bottom: 1px solid var(--lab-hairline);
+		font-size: 0.5rem;
+		color: var(--color-subtle);
+	}
+
+	ul {
+		display: grid;
+		gap: 0.18rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.cols a {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5rem;
+		text-decoration: none;
+		color: var(--color-heading);
+	}
+
+	.idx {
+		font-size: 0.5rem;
+		color: var(--color-subtle);
+		transition: color 200ms ease;
+	}
+
+	.label {
+		font-family: var(--font-ui);
+		font-size: 0.84rem;
+		font-weight: 500;
+		white-space: nowrap;
+		// Underline is drawn on the text box itself so descenders stay clear.
+		background-image: linear-gradient(var(--lab-accent), var(--lab-accent));
+		background-size: 0% 1.5px;
+		background-position: 0 100%;
+		background-repeat: no-repeat;
+		transition: background-size 280ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	.cols a:hover .label {
+		background-size: 100% 1.5px;
+	}
+
+	.cols a:hover .idx {
+		color: var(--lab-accent);
+	}
+
+	.strap {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		gap: 0.4rem 1.5rem;
+		margin-top: clamp(1rem, 3cqw, 2rem);
+		padding: 0.5rem 0;
+		border-top: 1px solid var(--lab-hairline);
+		font-size: 0.52rem;
+		color: var(--color-subtle);
+	}
+
+	@container (max-width: 700px) {
+		.top {
+			flex-direction: column;
+			gap: 1.25rem;
+		}
+
+		.wordmark {
+			font-size: clamp(2rem, 9cqw, 2.6rem);
+		}
+	}
+
+	@container (max-width: 420px) {
+		.strap span:nth-child(3) {
+			display: none;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/headers/H04StatusStrip.svelte
+++ b/personal-website/src/routes/lab/chrome/headers/H04StatusStrip.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	const links = ['Photos', 'Book notes', 'Writing', '2026', 'Contact'];
+
+	// The strip carries live-ish detail that would be stale in static markup,
+	// so the clock only starts once mounted.
+	let time = $state('--:--');
+
+	onMount(() => {
+		const tick = () =>
+			(time = new Intl.DateTimeFormat('en-AU', {
+				timeZone: 'Australia/Melbourne',
+				hour: '2-digit',
+				minute: '2-digit',
+				hour12: false
+			}).format(new Date()));
+		tick();
+		const id = setInterval(tick, 30_000);
+		return () => clearInterval(id);
+	});
+</script>
+
+<div class="stack">
+	<!-- Scrolls away with the page; only the nav row below it pins. -->
+	<div class="strip lab-mono">
+		<span class="live"><i></i> melbourne {time}</span>
+		<span class="mid">currently reading — <b data-preserve-case>Thinking, Fast and Slow</b></span>
+		<span class="right">new photos from sydney →</span>
+	</div>
+
+	<header class="bar">
+		<a class="brand" href="/" data-preserve-case>Matej Groombridge</a>
+		<nav aria-label="Primary">
+			<ul>
+				{#each links as link (link)}
+					<li><a href="/">{link}</a></li>
+				{/each}
+			</ul>
+		</nav>
+	</header>
+</div>
+
+<style lang="scss">
+	.stack {
+		position: relative;
+	}
+
+	.strip {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		padding: 0.45rem clamp(1rem, 4cqw, 2.5rem);
+		background: var(--color-heading);
+		color: color-mix(in srgb, var(--color-cream) 78%, transparent);
+		font-size: 0.54rem;
+	}
+
+	.live {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.4rem;
+		white-space: nowrap;
+	}
+
+	.live i {
+		width: 5px;
+		height: 5px;
+		border-radius: 999px;
+		background: var(--lab-accent);
+		box-shadow: 0 0 0 0 color-mix(in srgb, var(--lab-accent) 60%, transparent);
+		animation: ping 2.6s ease-out infinite;
+	}
+
+	@keyframes ping {
+		70%,
+		100% {
+			box-shadow: 0 0 0 6px transparent;
+		}
+	}
+
+	.strip b {
+		color: var(--color-cream);
+		font-weight: 500;
+	}
+
+	.right {
+		color: var(--lab-accent);
+		white-space: nowrap;
+	}
+
+	.bar {
+		position: sticky;
+		top: 0;
+		z-index: 5;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1.5rem;
+		padding: 0.9rem clamp(1rem, 4cqw, 2.5rem);
+		background: color-mix(in srgb, var(--color-cream) 90%, transparent);
+		backdrop-filter: blur(12px);
+		border-bottom: 1px solid var(--lab-hairline);
+	}
+
+	.brand {
+		font-family: var(--font-ui);
+		font-size: 0.95rem;
+		font-weight: 700;
+		letter-spacing: -0.035em;
+		color: var(--color-heading);
+		text-decoration: none;
+		white-space: nowrap;
+	}
+
+	ul {
+		display: flex;
+		gap: clamp(0.6rem, 2cqw, 1.4rem);
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	nav a {
+		font-family: var(--font-ui);
+		font-size: 0.82rem;
+		font-weight: 500;
+		color: var(--color-subtle);
+		text-decoration: none;
+		white-space: nowrap;
+		transition: color 180ms ease;
+	}
+
+	nav a:hover {
+		color: var(--lab-accent);
+	}
+
+	@container (max-width: 720px) {
+		.mid {
+			display: none;
+		}
+	}
+
+	@container (max-width: 560px) {
+		.right {
+			display: none;
+		}
+
+		.strip {
+			justify-content: flex-start;
+		}
+
+		.bar {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 0.6rem;
+		}
+
+		ul {
+			width: 100%;
+			overflow-x: auto;
+			scrollbar-width: none;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/headers/H05CommandBar.svelte
+++ b/personal-website/src/routes/lab/chrome/headers/H05CommandBar.svelte
@@ -1,0 +1,212 @@
+<script lang="ts">
+	// Nav collapses to a single affordance: everything on the site is reachable
+	// by typing, and the bar stops competing with the page for attention.
+	const recent = ['Sydney, March', 'Born To Run', 'On writing less'];
+	let open = $state(false);
+</script>
+
+<header class="bar">
+	<a class="brand" href="/" aria-label="Home">
+		<span class="mark" aria-hidden="true"></span>
+		<span class="name" data-preserve-case>Matej</span>
+	</a>
+
+	<div class="field-wrap">
+		<button class="field" type="button" onclick={() => (open = !open)} aria-expanded={open}>
+			<span class="glyph" aria-hidden="true">⌕</span>
+			<span class="placeholder">Search photos, books, writing…</span>
+			<kbd class="lab-mono" data-preserve-case>⌘K</kbd>
+		</button>
+
+		{#if open}
+			<div class="sheet">
+				<span class="sheet-label lab-mono">recent</span>
+				{#each recent as item (item)}
+					<a class="sheet-row" href="/" data-preserve-case>{item}</a>
+				{/each}
+			</div>
+		{/if}
+	</div>
+
+	<div class="actions">
+		<button type="button" aria-label="Toggle theme"><span class="dot"></span></button>
+		<a class="ghost" href="/">Contact</a>
+	</div>
+</header>
+
+<style lang="scss">
+	.bar {
+		position: sticky;
+		top: 0;
+		z-index: 5;
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr) auto;
+		align-items: center;
+		gap: clamp(0.6rem, 3cqw, 1.5rem);
+		padding: 0.75rem clamp(0.85rem, 4cqw, 2.5rem);
+		background: color-mix(in srgb, var(--color-cream) 88%, transparent);
+		backdrop-filter: blur(14px);
+		border-bottom: 1px solid var(--lab-hairline);
+	}
+
+	.brand {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		text-decoration: none;
+	}
+
+	.mark {
+		width: 22px;
+		height: 22px;
+		border-radius: 7px;
+		background: linear-gradient(140deg, var(--lab-accent), var(--color-heading));
+	}
+
+	.name {
+		font-family: var(--font-ui);
+		font-size: 0.95rem;
+		font-weight: 700;
+		letter-spacing: -0.035em;
+		color: var(--color-heading);
+	}
+
+	.field-wrap {
+		position: relative;
+		justify-self: center;
+		width: min(100%, 380px);
+	}
+
+	.field {
+		display: flex;
+		align-items: center;
+		gap: 0.55rem;
+		width: 100%;
+		padding: 0.45rem 0.45rem 0.45rem 0.7rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 999px;
+		background: var(--color-surface);
+		text-align: left;
+		transition:
+			border-color 200ms ease,
+			box-shadow 200ms ease;
+	}
+
+	.field:hover {
+		border-color: color-mix(in srgb, var(--lab-accent) 45%, transparent);
+		box-shadow: 0 0 0 3px color-mix(in srgb, var(--lab-accent) 10%, transparent);
+	}
+
+	.glyph {
+		font-size: 0.9rem;
+		color: var(--lab-accent);
+	}
+
+	.placeholder {
+		flex: 1;
+		min-width: 0;
+		font-size: 0.8rem;
+		color: var(--color-subtle);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	kbd {
+		flex: 0 0 auto;
+		padding: 0.14rem 0.36rem;
+		border: 1px solid var(--lab-hairline);
+		border-bottom-width: 2px;
+		border-radius: var(--radius-sm);
+		background: var(--color-muted);
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+	}
+
+	.sheet {
+		position: absolute;
+		top: calc(100% + 0.4rem);
+		left: 0;
+		right: 0;
+		display: grid;
+		padding: 0.35rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-md);
+		background: var(--color-surface);
+		box-shadow: 0 18px 40px -20px rgb(0 0 0 / 0.4);
+		animation: drop 180ms cubic-bezier(0.2, 0.9, 0.3, 1.1);
+	}
+
+	@keyframes drop {
+		from {
+			opacity: 0;
+			transform: translateY(-6px);
+		}
+	}
+
+	.sheet-label {
+		padding: 0.35rem 0.5rem 0.2rem;
+		font-size: 0.5rem;
+		color: var(--color-subtle);
+	}
+
+	.sheet-row {
+		padding: 0.4rem 0.5rem;
+		border-radius: var(--radius-sm);
+		font-size: 0.82rem;
+		color: var(--color-heading);
+		text-decoration: none;
+	}
+
+	.sheet-row:hover {
+		background: color-mix(in srgb, var(--lab-accent) 12%, transparent);
+	}
+
+	.actions {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	.actions button {
+		display: grid;
+		place-items: center;
+		width: 1.9rem;
+		height: 1.9rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 999px;
+		background: var(--color-surface);
+	}
+
+	.dot {
+		width: 10px;
+		height: 10px;
+		border-radius: 999px;
+		background: linear-gradient(90deg, var(--color-heading) 50%, var(--color-muted) 50%);
+		border: 1px solid var(--color-heading);
+	}
+
+	.ghost {
+		padding: 0.4rem 0.8rem;
+		border-radius: 999px;
+		background: var(--color-heading);
+		font-family: var(--font-ui);
+		font-size: 0.78rem;
+		font-weight: 600;
+		color: var(--color-cream);
+		text-decoration: none;
+		white-space: nowrap;
+	}
+
+	@container (max-width: 620px) {
+		// The search affordance is the nav, so it keeps its space and the
+		// secondary call to action is what gives way.
+		.ghost {
+			display: none;
+		}
+
+		.name {
+			display: none;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/headers/H06Index.svelte
+++ b/personal-website/src/routes/lab/chrome/headers/H06Index.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+	const entries = [
+		{ label: 'Photography', meta: '14 trips' },
+		{ label: 'Book notes', meta: '33 notes' },
+		{ label: 'Writing', meta: '6 essays' },
+		{ label: '2026', meta: 'live' },
+		{ label: 'Contact', meta: '' }
+	];
+	let hovered = $state<number | null>(null);
+</script>
+
+<header class="index">
+	<a class="brand" href="/">
+		<span class="brand-name" data-preserve-case>Matej Groombridge</span>
+		<span class="brand-role lab-mono">index</span>
+	</a>
+
+	<nav aria-label="Primary" onmouseleave={() => (hovered = null)}>
+		<ol>
+			{#each entries as entry, i (entry.label)}
+				<li class:dim={hovered !== null && hovered !== i}>
+					<a href="/" onmouseenter={() => (hovered = i)} onfocus={() => (hovered = i)}>
+						<span class="num lab-mono">{String(i + 1).padStart(2, '0')}</span>
+						<span class="label" data-preserve-case>{entry.label}</span>
+						<span class="leader" aria-hidden="true"></span>
+						{#if entry.meta}
+							<span class="meta lab-mono">{entry.meta}</span>
+						{/if}
+					</a>
+				</li>
+			{/each}
+		</ol>
+	</nav>
+</header>
+
+<style lang="scss">
+	.index {
+		position: sticky;
+		top: 0;
+		z-index: 5;
+		padding: clamp(1rem, 3cqw, 1.6rem) clamp(1rem, 4cqw, 2.5rem);
+		background: var(--color-cream);
+		border-bottom: 1px solid var(--lab-hairline);
+	}
+
+	.brand {
+		display: flex;
+		align-items: baseline;
+		gap: 0.6rem;
+		margin-bottom: 0.85rem;
+		text-decoration: none;
+	}
+
+	.brand-name {
+		font-family: var(--font-ui);
+		font-size: 1rem;
+		font-weight: 700;
+		letter-spacing: -0.04em;
+		color: var(--color-heading);
+	}
+
+	.brand-role {
+		font-size: 0.5rem;
+		color: var(--color-subtle);
+	}
+
+	ol {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+		gap: 0.15rem clamp(1rem, 3cqw, 2rem);
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	li {
+		transition: opacity 220ms ease;
+	}
+
+	// Hovering one entry recedes the rest, which is what makes a list of five
+	// links read as a table of contents rather than a row of buttons.
+	li.dim {
+		opacity: 0.35;
+	}
+
+	a {
+		display: flex;
+		align-items: baseline;
+		gap: 0.5rem;
+		padding: 0.28rem 0;
+		text-decoration: none;
+		color: var(--color-heading);
+	}
+
+	.num {
+		font-size: 0.52rem;
+		color: var(--lab-accent);
+	}
+
+	.label {
+		font-family: var(--font-ui);
+		font-size: 0.86rem;
+		font-weight: 500;
+		white-space: nowrap;
+	}
+
+	// Dotted leader, the way a printed contents page runs the eye to the number.
+	.leader {
+		flex: 1;
+		min-width: 0.75rem;
+		height: 1px;
+		border-bottom: 1px dotted var(--lab-hairline);
+		transform: translateY(-0.2em);
+	}
+
+	.meta {
+		font-size: 0.5rem;
+		color: var(--color-subtle);
+		white-space: nowrap;
+	}
+
+	a:hover .label {
+		color: var(--lab-accent);
+	}
+
+	@container (max-width: 480px) {
+		ol {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/headers/H07Rail.svelte
+++ b/personal-website/src/routes/lab/chrome/headers/H07Rail.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+	const links = ['Photos', 'Books', 'Writing', '2026', 'Contact'];
+	const socials = ['IG', 'GH', 'IN'];
+	let active = $state(0);
+</script>
+
+<header class="rail">
+	<a class="brand" href="/" aria-label="Home">
+		<span class="mark" aria-hidden="true">M</span>
+	</a>
+
+	<nav aria-label="Primary">
+		<ul>
+			{#each links as link, i (link)}
+				<li>
+					<a
+						href="/"
+						class:on={active === i}
+						aria-current={active === i ? 'page' : undefined}
+						onclick={(event) => {
+							event.preventDefault();
+							active = i;
+						}}
+					>
+						<span class="tick" aria-hidden="true"></span>
+						<span class="label">{link}</span>
+					</a>
+				</li>
+			{/each}
+		</ul>
+	</nav>
+
+	<ul class="socials lab-mono">
+		{#each socials as social (social)}
+			<li><a href="/" data-preserve-case>{social}</a></li>
+		{/each}
+	</ul>
+</header>
+
+<style lang="scss">
+	// Sticky inside the scroll container and only as tall as the viewport, so
+	// the page slides past a nav that never moves.
+	.rail {
+		position: sticky;
+		top: 0;
+		z-index: 5;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		flex: 0 0 auto;
+		align-self: flex-start;
+		width: 68px;
+		height: var(--viewport-h, 440px);
+		padding: 0.85rem 0;
+		overflow: hidden;
+		border-right: 1px solid var(--lab-hairline);
+		background: var(--color-surface);
+	}
+
+	.mark {
+		display: grid;
+		place-items: center;
+		width: 30px;
+		height: 30px;
+		border-radius: 9px;
+		background: var(--color-heading);
+		font-family: var(--font-ui);
+		font-size: 0.85rem;
+		font-weight: 800;
+		color: var(--color-cream);
+	}
+
+	.brand {
+		text-decoration: none;
+	}
+
+	nav ul {
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		// Sized so the full stack — monogram, five rotated labels, socials —
+		// still fits a short viewport without the bottom group being clipped.
+		gap: 1rem;
+		min-height: 0;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	nav a {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		text-decoration: none;
+		color: var(--color-subtle);
+		// Rotated so the labels read bottom-to-top down the rail.
+		writing-mode: vertical-rl;
+		transform: rotate(180deg);
+		transition: color 200ms ease;
+	}
+
+	nav a:hover,
+	nav a.on {
+		color: var(--color-heading);
+	}
+
+	.label {
+		font-family: var(--font-ui);
+		font-size: 0.72rem;
+		font-weight: 500;
+		letter-spacing: 0.02em;
+	}
+
+	.tick {
+		width: 5px;
+		height: 5px;
+		border-radius: 999px;
+		background: var(--lab-accent);
+		opacity: 0;
+		transform: scale(0.4);
+		transition:
+			opacity 220ms ease,
+			transform 260ms cubic-bezier(0.3, 1.4, 0.4, 1);
+	}
+
+	nav a.on .tick {
+		opacity: 1;
+		transform: scale(1);
+	}
+
+	.socials {
+		display: flex;
+		flex-direction: column;
+		flex: 0 0 auto;
+		gap: 0.45rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+		text-align: center;
+	}
+
+	.socials a {
+		font-size: 0.5rem;
+		color: var(--color-subtle);
+		text-decoration: none;
+	}
+
+	.socials a:hover {
+		color: var(--lab-accent);
+	}
+
+	@container (max-width: 560px) {
+		// A vertical rail costs too much width on a phone, so it lies down and
+		// becomes a conventional bottom-anchored bar.
+		.rail {
+			position: sticky;
+			top: 0;
+			flex-direction: row;
+			width: 100%;
+			height: auto;
+			padding: 0.6rem 0.85rem;
+			border-right: none;
+			border-bottom: 1px solid var(--lab-hairline);
+		}
+
+		nav ul {
+			flex-direction: row;
+			gap: 0.9rem;
+		}
+
+		nav a {
+			writing-mode: horizontal-tb;
+			transform: none;
+		}
+
+		.socials {
+			display: none;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/headers/H08Overlay.svelte
+++ b/personal-website/src/routes/lab/chrome/headers/H08Overlay.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+	import { photoTrips } from '$lib/content';
+
+	const links = [
+		{ label: 'Photography', image: photoTrips[0]?.coverImage },
+		{ label: 'Book notes', image: photoTrips[1]?.coverImage },
+		{ label: 'Writing', image: photoTrips[2]?.coverImage },
+		{ label: '2026', image: photoTrips[3]?.coverImage },
+		{ label: 'Contact', image: photoTrips[4]?.coverImage }
+	];
+
+	let open = $state(false);
+	let hovered = $state(0);
+</script>
+
+<header class="bar" class:open>
+	<a class="brand" href="/" data-preserve-case>Matej Groombridge</a>
+	<button class="toggle" type="button" aria-expanded={open} onclick={() => (open = !open)}>
+		<span class="toggle-label lab-mono">{open ? 'close' : 'menu'}</span>
+		<span class="burger" aria-hidden="true"><i></i><i></i></span>
+	</button>
+</header>
+
+{#if open}
+	<div class="overlay">
+		<!-- The preview image cross-fades behind the list as you move down it. -->
+		<div class="art" aria-hidden="true">
+			{#each links as link, i (link.label)}
+				{#if link.image}
+					<img src={link.image} alt="" class:showing={hovered === i} />
+				{/if}
+			{/each}
+		</div>
+
+		<nav aria-label="Primary">
+			<ul>
+				{#each links as link, i (link.label)}
+					<li style={`--d:${i * 55}ms`}>
+						<a href="/" onmouseenter={() => (hovered = i)} onfocus={() => (hovered = i)}>
+							<span class="num lab-mono">{String(i + 1).padStart(2, '0')}</span>
+							<span class="big" data-preserve-case>{link.label}</span>
+						</a>
+					</li>
+				{/each}
+			</ul>
+		</nav>
+	</div>
+{/if}
+
+<style lang="scss">
+	.bar {
+		position: sticky;
+		top: 0;
+		z-index: 7;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		padding: 1rem clamp(1rem, 4cqw, 2.5rem);
+		background: color-mix(in srgb, var(--color-cream) 88%, transparent);
+		backdrop-filter: blur(12px);
+	}
+
+	.bar.open {
+		background: transparent;
+		backdrop-filter: none;
+	}
+
+	.brand {
+		font-family: var(--font-ui);
+		font-size: 0.95rem;
+		font-weight: 700;
+		letter-spacing: -0.035em;
+		color: var(--color-heading);
+		text-decoration: none;
+		position: relative;
+		z-index: 8;
+	}
+
+	.toggle {
+		position: relative;
+		z-index: 8;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.35rem 0.7rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 999px;
+		background: var(--color-surface);
+	}
+
+	.toggle-label {
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+	}
+
+	.burger {
+		display: grid;
+		gap: 3px;
+		width: 14px;
+	}
+
+	.burger i {
+		display: block;
+		height: 1.5px;
+		background: var(--color-heading);
+		transition: transform 300ms cubic-bezier(0.2, 0.9, 0.3, 1.2);
+	}
+
+	.bar.open .burger i:first-child {
+		transform: translateY(2.25px) rotate(45deg);
+	}
+
+	.bar.open .burger i:last-child {
+		transform: translateY(-2.25px) rotate(-45deg);
+	}
+
+	.overlay {
+		position: absolute;
+		inset: 0;
+		z-index: 6;
+		display: grid;
+		align-content: center;
+		padding: 3.5rem clamp(1rem, 4cqw, 2.5rem) 1.5rem;
+		background: var(--color-cream);
+		overflow: hidden;
+		animation: wipe 320ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	@keyframes wipe {
+		from {
+			clip-path: inset(0 0 100% 0);
+		}
+	}
+
+	.art {
+		position: absolute;
+		inset: 0;
+		opacity: 0.22;
+	}
+
+	.art img {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		opacity: 0;
+		transform: scale(1.06);
+		transition:
+			opacity 500ms ease,
+			transform 900ms ease;
+	}
+
+	.art img.showing {
+		opacity: 1;
+		transform: scale(1);
+	}
+
+	nav {
+		position: relative;
+	}
+
+	ul {
+		display: grid;
+		gap: 0.1rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	li {
+		opacity: 0;
+		transform: translateY(14px);
+		animation: rise 460ms cubic-bezier(0.2, 0.9, 0.3, 1) var(--d) forwards;
+	}
+
+	@keyframes rise {
+		to {
+			opacity: 1;
+			transform: none;
+		}
+	}
+
+	nav a {
+		display: flex;
+		align-items: baseline;
+		gap: 0.85rem;
+		text-decoration: none;
+		color: var(--color-heading);
+	}
+
+	.num {
+		font-size: 0.55rem;
+		color: var(--lab-accent);
+	}
+
+	.big {
+		font-family: var(--font-display);
+		font-size: clamp(1.6rem, 7cqw, 3rem);
+		font-weight: 500;
+		line-height: 1.06;
+		letter-spacing: -0.035em;
+		font-variation-settings: 'SOFT' 40;
+		transition:
+			transform 320ms cubic-bezier(0.2, 0.9, 0.3, 1),
+			font-variation-settings 320ms ease;
+	}
+
+	nav a:hover .big {
+		transform: translateX(10px);
+		font-variation-settings: 'SOFT' 90;
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/headers/H09AutoHide.svelte
+++ b/personal-website/src/routes/lab/chrome/headers/H09AutoHide.svelte
@@ -1,0 +1,131 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { onFrameScroll, scrollHost } from '../scrollHost';
+
+	const links = ['Photos', 'Book notes', 'Writing', '2026', 'Contact'];
+
+	let el = $state<HTMLElement>();
+	let hidden = $state(false);
+	let progress = $state(0);
+
+	onMount(() => {
+		if (!el) return;
+		const host = scrollHost(el);
+
+		return onFrameScroll(host, (top, delta) => {
+			// Never hide near the top, and require a deliberate movement in one
+			// direction so trackpad jitter can't strobe the header.
+			if (top < 80) hidden = false;
+			else if (delta > 4) hidden = true;
+			else if (delta < -4) hidden = false;
+
+			if (host instanceof Window) {
+				const max = document.documentElement.scrollHeight - window.innerHeight;
+				progress = max > 0 ? top / max : 0;
+			} else {
+				const max = host.scrollHeight - host.clientHeight;
+				progress = max > 0 ? top / max : 0;
+			}
+		});
+	});
+</script>
+
+<header class="bar" class:hidden bind:this={el}>
+	<div class="row">
+		<a class="brand" href="/" data-preserve-case>Matej Groombridge</a>
+		<nav aria-label="Primary">
+			<ul>
+				{#each links as link (link)}
+					<li><a href="/">{link}</a></li>
+				{/each}
+			</ul>
+		</nav>
+	</div>
+	<div class="progress" aria-hidden="true">
+		<span style={`transform:scaleX(${progress})`}></span>
+	</div>
+</header>
+
+<style lang="scss">
+	.bar {
+		position: sticky;
+		top: 0;
+		z-index: 5;
+		background: color-mix(in srgb, var(--color-cream) 92%, transparent);
+		backdrop-filter: blur(12px);
+		border-bottom: 1px solid var(--lab-hairline);
+		transition: transform 340ms cubic-bezier(0.3, 0.9, 0.3, 1);
+	}
+
+	// Slides out by its own height rather than a guessed pixel value, so it
+	// stays correct at any padding or font size.
+	.bar.hidden {
+		transform: translateY(-100%);
+	}
+
+	.row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1.5rem;
+		padding: 0.9rem clamp(1rem, 4cqw, 2.5rem);
+	}
+
+	.brand {
+		font-family: var(--font-ui);
+		font-size: 0.95rem;
+		font-weight: 700;
+		letter-spacing: -0.035em;
+		color: var(--color-heading);
+		text-decoration: none;
+		white-space: nowrap;
+	}
+
+	ul {
+		display: flex;
+		gap: clamp(0.6rem, 2cqw, 1.4rem);
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	nav a {
+		font-family: var(--font-ui);
+		font-size: 0.82rem;
+		font-weight: 500;
+		color: var(--color-subtle);
+		text-decoration: none;
+		white-space: nowrap;
+	}
+
+	nav a:hover {
+		color: var(--color-heading);
+	}
+
+	.progress {
+		height: 2px;
+		background: transparent;
+	}
+
+	.progress span {
+		display: block;
+		height: 100%;
+		background: var(--lab-accent);
+		transform-origin: left center;
+		transform: scaleX(0);
+	}
+
+	@container (max-width: 600px) {
+		.row {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 0.55rem;
+		}
+
+		ul {
+			width: 100%;
+			overflow-x: auto;
+			scrollbar-width: none;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/headers/H10PhotoStrip.svelte
+++ b/personal-website/src/routes/lab/chrome/headers/H10PhotoStrip.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { photoTrips } from '$lib/content';
+	import { onFrameScroll, scrollHost } from '../scrollHost';
+
+	const links = ['Photos', 'Book notes', 'Writing', '2026', 'Contact'];
+	const cover = photoTrips[0]?.coverImage ?? '';
+
+	let el = $state<HTMLElement>();
+	let solid = $state(0);
+
+	onMount(() => {
+		if (!el) return;
+		// A continuous 0→1 ramp over the first 160px rather than a class flip, so
+		// the header dissolves from photo to paper instead of snapping.
+		return onFrameScroll(scrollHost(el), (top) => {
+			solid = Math.min(1, Math.max(0, top / 160));
+		});
+	});
+</script>
+
+<header class="bar" bind:this={el} style={`--solid:${solid}`}>
+	<div class="photo" aria-hidden="true" style={`background-image:url(${cover})`}></div>
+	<div class="paper" aria-hidden="true"></div>
+
+	<div class="row">
+		<a class="brand" href="/" data-preserve-case>Matej Groombridge</a>
+		<nav aria-label="Primary">
+			<ul>
+				{#each links as link (link)}
+					<li><a href="/">{link}</a></li>
+				{/each}
+			</ul>
+		</nav>
+		<span class="stamp lab-mono">sydney · 03/25</span>
+	</div>
+</header>
+
+<style lang="scss">
+	.bar {
+		--solid: 0;
+		position: sticky;
+		top: 0;
+		z-index: 5;
+		isolation: isolate;
+	}
+
+	.photo,
+	.paper {
+		position: absolute;
+		inset: 0;
+		z-index: -1;
+	}
+
+	.photo {
+		background-size: cover;
+		background-position: center 62%;
+	}
+
+	// Paper fades in over the photograph as the ramp climbs, and the border
+	// only appears once the header is properly opaque.
+	.paper {
+		background: var(--color-cream);
+		opacity: var(--solid);
+		border-bottom: 1px solid
+			color-mix(in srgb, var(--lab-hairline) calc(var(--solid) * 100%), transparent);
+	}
+
+	.row {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1.25rem;
+		padding: clamp(0.9rem, 3cqw, 1.5rem) clamp(1rem, 4cqw, 2.5rem);
+	}
+
+	.brand,
+	nav a,
+	.stamp {
+		// Both colours are always present; the ramp cross-mixes between them, so
+		// text over the photograph is white and text over paper is ink.
+		color: color-mix(in srgb, var(--color-heading) calc(var(--solid) * 100%), #ffffff);
+		text-decoration: none;
+	}
+
+	.brand {
+		font-family: var(--font-ui);
+		font-size: 0.95rem;
+		font-weight: 700;
+		letter-spacing: -0.035em;
+		white-space: nowrap;
+		text-shadow: 0 1px 12px rgb(0 0 0 / calc(0.45 * (1 - var(--solid))));
+	}
+
+	ul {
+		display: flex;
+		gap: clamp(0.6rem, 2cqw, 1.4rem);
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	nav a {
+		font-family: var(--font-ui);
+		font-size: 0.82rem;
+		font-weight: 550;
+		white-space: nowrap;
+		text-shadow: 0 1px 10px rgb(0 0 0 / calc(0.4 * (1 - var(--solid))));
+	}
+
+	nav a:hover {
+		color: var(--lab-accent);
+	}
+
+	.stamp {
+		font-size: 0.5rem;
+		opacity: calc(1 - var(--solid));
+		white-space: nowrap;
+	}
+
+	@container (max-width: 720px) {
+		.stamp {
+			display: none;
+		}
+	}
+
+	@container (max-width: 560px) {
+		.row {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 0.55rem;
+		}
+
+		ul {
+			width: 100%;
+			overflow-x: auto;
+			scrollbar-width: none;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/chrome/scrollHost.ts
+++ b/personal-website/src/routes/lab/chrome/scrollHost.ts
@@ -1,0 +1,51 @@
+/**
+ * Chrome on this page is previewed inside a scrolling box, not the page itself,
+ * so anything that reacts to scrolling has to listen to whichever ancestor is
+ * actually doing the scrolling. Falls back to the window when the component is
+ * dropped into a real page, which is where it would eventually live.
+ */
+export function scrollHost(node: HTMLElement): HTMLElement | Window {
+	let parent = node.parentElement;
+	while (parent) {
+		const overflowY = getComputedStyle(parent).overflowY;
+		if (overflowY === 'auto' || overflowY === 'scroll') return parent;
+		parent = parent.parentElement;
+	}
+	return window;
+}
+
+/** Current scroll offset of either a scrolling element or the window. */
+export function scrollTopOf(host: HTMLElement | Window): number {
+	return host instanceof Window ? host.scrollY : host.scrollTop;
+}
+
+/**
+ * Subscribes to scroll on `host` and calls `onScroll` at most once per frame
+ * with the current offset and the delta since the previous frame.
+ */
+export function onFrameScroll(
+	host: HTMLElement | Window,
+	onScroll: (top: number, delta: number) => void
+) {
+	let raf = 0;
+	let last = scrollTopOf(host);
+
+	const tick = () => {
+		raf = 0;
+		const top = scrollTopOf(host);
+		onScroll(top, top - last);
+		last = top;
+	};
+
+	const handler = () => {
+		if (!raf) raf = requestAnimationFrame(tick);
+	};
+
+	host.addEventListener('scroll', handler, { passive: true });
+	onScroll(last, 0);
+
+	return () => {
+		host.removeEventListener('scroll', handler);
+		if (raf) cancelAnimationFrame(raf);
+	};
+}

--- a/personal-website/src/routes/lab/concepts/AuroraHero.svelte
+++ b/personal-website/src/routes/lab/concepts/AuroraHero.svelte
@@ -1,0 +1,251 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	type Blob = {
+		x: number;
+		y: number;
+		r: number;
+		hue: number;
+		sx: number;
+		sy: number;
+		px: number;
+		py: number;
+	};
+
+	let canvas = $state<HTMLCanvasElement>();
+	let wrap = $state<HTMLDivElement>();
+
+	onMount(() => {
+		const el = canvas;
+		const host = wrap;
+		if (!el || !host) return;
+
+		const ctx = el.getContext('2d');
+		if (!ctx) return;
+
+		const reduce = window.matchMedia('(prefers-reduced-motion: reduce)');
+		let width = 0;
+		let height = 0;
+
+		// Six slow-drifting radial blooms. Painted at quarter resolution and
+		// stretched back up by CSS — the upscale blur is what sells the aurora and
+		// keeps the per-frame cost near zero.
+		const blobs: Blob[] = Array.from({ length: 6 }, (_, i) => ({
+			x: Math.random(),
+			y: Math.random(),
+			r: 0.34 + Math.random() * 0.3,
+			hue: i,
+			sx: 0.06 + Math.random() * 0.09,
+			sy: 0.05 + Math.random() * 0.08,
+			px: Math.random() * Math.PI * 2,
+			py: Math.random() * Math.PI * 2
+		}));
+
+		function palette() {
+			const styles = getComputedStyle(host!);
+			const accent = styles.getPropertyValue('--lab-accent').trim() || '#00ab44';
+			const soft = styles.getPropertyValue('--color-green-soft').trim() || '#57ba86';
+			const surface = styles.getPropertyValue('--color-surface').trim() || '#fffdf8';
+			return [accent, soft, surface, accent, soft, surface];
+		}
+
+		let colours = palette();
+
+		function resize() {
+			const rect = host!.getBoundingClientRect();
+			// Quarter-res buffer: the CSS blur hides every bit of the lost detail.
+			width = el!.width = Math.max(1, Math.round(rect.width / 4));
+			height = el!.height = Math.max(1, Math.round(rect.height / 4));
+			colours = palette();
+		}
+
+		resize();
+		const ro = new ResizeObserver(resize);
+		ro.observe(host);
+
+		const themeObserver = new MutationObserver(() => {
+			colours = palette();
+		});
+		themeObserver.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ['data-theme']
+		});
+
+		let raf = 0;
+		let visible = true;
+
+		const io = new IntersectionObserver(
+			([entry]) => {
+				visible = entry.isIntersecting;
+				if (visible && !raf) raf = requestAnimationFrame(frame);
+			},
+			{ threshold: 0 }
+		);
+		io.observe(host);
+
+		function paint(t: number) {
+			if (!ctx) return;
+			ctx.clearRect(0, 0, width, height);
+			ctx.globalCompositeOperation = 'lighter';
+
+			for (let i = 0; i < blobs.length; i++) {
+				const b = blobs[i];
+				const cx = (0.5 + Math.sin(t * b.sx + b.px) * 0.42) * width;
+				const cy = (0.5 + Math.cos(t * b.sy + b.py) * 0.42) * height;
+				const radius = b.r * Math.max(width, height);
+
+				const grad = ctx.createRadialGradient(cx, cy, 0, cx, cy, radius);
+				grad.addColorStop(0, colours[i % colours.length]);
+				grad.addColorStop(1, 'transparent');
+				ctx.fillStyle = grad;
+				ctx.globalAlpha = 0.42;
+				ctx.beginPath();
+				ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+				ctx.fill();
+			}
+
+			ctx.globalAlpha = 1;
+			ctx.globalCompositeOperation = 'source-over';
+		}
+
+		function frame(now: number) {
+			raf = 0;
+			if (!visible) return;
+			paint(now / 1000);
+			raf = requestAnimationFrame(frame);
+		}
+
+		if (reduce.matches) {
+			paint(0);
+		} else {
+			raf = requestAnimationFrame(frame);
+		}
+
+		return () => {
+			ro.disconnect();
+			io.disconnect();
+			themeObserver.disconnect();
+			if (raf) cancelAnimationFrame(raf);
+		};
+	});
+</script>
+
+<div class="aurora lab-grain" bind:this={wrap}>
+	<canvas bind:this={canvas} aria-hidden="true"></canvas>
+	<div class="veil" aria-hidden="true"></div>
+	<div class="content">
+		<span class="lab-chip" data-tone="accent">melbourne · 37.8°s</span>
+		<h3>Software by day,<br />a camera the rest of the time.</h3>
+		<p>
+			A living index of what I&rsquo;m building, reading and shooting — updated far more often than
+			it is redesigned.
+		</p>
+		<div class="actions">
+			<a class="btn primary" href="/photography">See the photographs</a>
+			<a class="btn ghost" href="/booknotes">Read the book notes</a>
+		</div>
+	</div>
+</div>
+
+<style lang="scss">
+	.aurora {
+		position: relative;
+		display: grid;
+		place-items: center;
+		min-height: clamp(320px, 46vw, 460px);
+		padding: clamp(1.75rem, 5vw, 3.5rem);
+		border-radius: var(--radius-md);
+		overflow: hidden;
+		isolation: isolate;
+		background: var(--color-surface);
+	}
+
+	canvas {
+		position: absolute;
+		inset: -12%;
+		width: 124%;
+		height: 124%;
+		// The buffer is a sixteenth of the pixels; blur turns that into gradient.
+		filter: blur(46px) saturate(1.35);
+		opacity: 0.85;
+		z-index: -2;
+	}
+
+	// Knocks the aurora back so text keeps its contrast in both themes.
+	.veil {
+		position: absolute;
+		inset: 0;
+		z-index: -1;
+		background: linear-gradient(
+			to bottom,
+			color-mix(in srgb, var(--color-surface) 55%, transparent),
+			color-mix(in srgb, var(--color-surface) 88%, transparent)
+		);
+	}
+
+	.content {
+		display: grid;
+		justify-items: center;
+		gap: 1rem;
+		max-width: 46ch;
+		text-align: center;
+	}
+
+	h3 {
+		margin: 0;
+		font-family: var(--font-display);
+		font-size: clamp(1.7rem, 4.2vw, 3rem);
+		font-weight: 500;
+		line-height: 1.08;
+		letter-spacing: -0.03em;
+		font-variation-settings: 'SOFT' 45;
+	}
+
+	p {
+		margin: 0;
+		color: var(--color-subtle);
+		font-size: clamp(0.95rem, 1.2vw, 1.05rem);
+		line-height: 1.6;
+	}
+
+	.actions {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: center;
+		gap: 0.5rem;
+		margin-top: 0.35rem;
+	}
+
+	.btn {
+		display: inline-flex;
+		align-items: center;
+		min-height: 2.5rem;
+		padding: 0 1.1rem;
+		border: 1px solid transparent;
+		border-radius: 999px;
+		font-family: var(--font-ui);
+		font-size: 0.88rem;
+		font-weight: 600;
+		text-decoration: none;
+		backdrop-filter: blur(8px);
+		transition:
+			transform var(--duration-fast) ease,
+			box-shadow var(--duration-fast) ease;
+	}
+
+	.btn:hover {
+		transform: translateY(-2px);
+		box-shadow: var(--shadow-soft);
+	}
+
+	.primary {
+		background: var(--lab-accent);
+		color: #fff;
+	}
+
+	.ghost {
+		border-color: var(--lab-hairline);
+		background: color-mix(in srgb, var(--color-surface) 62%, transparent);
+		color: var(--color-heading);
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/Bookshelf.svelte
+++ b/personal-website/src/routes/lab/concepts/Bookshelf.svelte
@@ -1,0 +1,334 @@
+<script lang="ts">
+	import { bookNotes } from '$lib/content';
+
+	const books = bookNotes.slice(0, 18);
+
+	let rail = $state<HTMLDivElement>();
+	let dragging = $state(false);
+	let moved = 0;
+	let startX = 0;
+	let startScroll = 0;
+
+	function onPointerDown(event: PointerEvent) {
+		if (!rail || event.pointerType === 'touch') return;
+		dragging = true;
+		moved = 0;
+		startX = event.clientX;
+		startScroll = rail.scrollLeft;
+		rail.setPointerCapture(event.pointerId);
+	}
+
+	function onPointerMove(event: PointerEvent) {
+		if (!dragging || !rail) return;
+		const delta = event.clientX - startX;
+		moved = Math.max(moved, Math.abs(delta));
+		rail.scrollLeft = startScroll - delta;
+	}
+
+	function onPointerUp(event: PointerEvent) {
+		if (!rail) return;
+		dragging = false;
+		if (rail.hasPointerCapture(event.pointerId)) rail.releasePointerCapture(event.pointerId);
+	}
+
+	/** Swallow the click that ends a drag so panning never navigates. */
+	function onClickCapture(event: MouseEvent) {
+		if (moved > 6) {
+			event.preventDefault();
+			event.stopPropagation();
+		}
+		moved = 0;
+	}
+
+	function ratingWidth(rating: string) {
+		const out = Number.parseFloat(rating);
+		return Number.isFinite(out) ? `${Math.min(100, out * 10)}%` : '0%';
+	}
+</script>
+
+<div class="shelf">
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div
+		class="rail"
+		class:dragging
+		bind:this={rail}
+		onpointerdown={onPointerDown}
+		onpointermove={onPointerMove}
+		onpointerup={onPointerUp}
+		onpointercancel={onPointerUp}
+		onclickcapture={onClickCapture}
+	>
+		<div class="run">
+			{#each books as book, i (book.slug)}
+				<a
+					class="slot"
+					href={`/booknotes/${book.slug}`}
+					style={`--i:${i}; --tilt:${((i * 37) % 7) - 3}deg`}
+					aria-label={`${book.title} by ${book.author}`}
+				>
+					<span class="book">
+						<span class="spine">
+							<span class="spine-text" data-preserve-case>{book.title}</span>
+							<span class="spine-mark" aria-hidden="true"></span>
+						</span>
+						<span class="cover">
+							<img src={book.cover} alt="" loading="lazy" width="120" height="180" />
+							<span class="sheen" aria-hidden="true"></span>
+						</span>
+						<span class="pages" aria-hidden="true"></span>
+					</span>
+					<span class="plate">
+						<span class="plate-title" data-preserve-case>{book.title}</span>
+						<span class="plate-author">{book.author}</span>
+						<span class="bar" aria-hidden="true">
+							<span class="bar-fill" style={`width:${ratingWidth(book.rating)}`}></span>
+						</span>
+					</span>
+				</a>
+			{/each}
+		</div>
+	</div>
+	<div class="board" aria-hidden="true"></div>
+	<p class="hint lab-mono">drag the shelf · hover a spine to pull the book out</p>
+</div>
+
+<style lang="scss">
+	.shelf {
+		position: relative;
+		display: grid;
+		gap: 0;
+	}
+
+	.rail {
+		// Deep perspective keeps the spines convincing without warping the ends.
+		perspective: 1400px;
+		perspective-origin: 50% 42%;
+		overflow-x: auto;
+		overflow-y: hidden;
+		padding: 4.5rem 1.25rem 0.5rem;
+		scrollbar-width: none;
+		cursor: grab;
+	}
+
+	.rail::-webkit-scrollbar {
+		display: none;
+	}
+
+	.rail.dragging {
+		cursor: grabbing;
+	}
+
+	.run {
+		display: flex;
+		align-items: flex-end;
+		gap: 3px;
+		width: max-content;
+		transform-style: preserve-3d;
+	}
+
+	.slot {
+		position: relative;
+		flex: 0 0 auto;
+		width: 34px;
+		height: 186px;
+		text-decoration: none;
+		color: inherit;
+		transform-style: preserve-3d;
+	}
+
+	.book {
+		position: absolute;
+		left: 0;
+		bottom: 0;
+		width: 124px;
+		height: 186px;
+		transform-origin: left bottom;
+		transform-style: preserve-3d;
+		// Edge-on by default: the spine faces the reader, the cover is a sliver.
+		transform: rotateY(-70deg) rotateZ(var(--tilt)) translateZ(0);
+		transition: transform 520ms cubic-bezier(0.22, 1, 0.28, 1);
+	}
+
+	.slot:hover .book,
+	.slot:focus-visible .book {
+		transform: rotateY(-13deg) rotateZ(0deg) translate3d(6px, -22px, 60px);
+	}
+
+	.slot:hover,
+	.slot:focus-visible {
+		z-index: 5;
+	}
+
+	.cover,
+	.spine,
+	.pages {
+		position: absolute;
+		inset: 0;
+		border-radius: 2px 4px 4px 2px;
+		backface-visibility: hidden;
+	}
+
+	.cover {
+		overflow: hidden;
+		background: var(--color-muted-strong);
+		box-shadow:
+			inset 1px 0 0 rgb(255 255 255 / 0.25),
+			0 12px 26px rgb(0 0 0 / 0.24);
+	}
+
+	.cover img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	.sheen {
+		position: absolute;
+		inset: 0;
+		background: linear-gradient(
+			104deg,
+			rgb(255 255 255 / 0.42) 0%,
+			transparent 34%,
+			transparent 66%,
+			rgb(0 0 0 / 0.16) 100%
+		);
+	}
+
+	// The spine hinges off the cover's left edge, so it stands perpendicular to
+	// the cover in 3D and reads as the visible face while the book is shelved.
+	.spine {
+		width: 32px;
+		transform-origin: left center;
+		transform: rotateY(90deg);
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 0.5rem 0;
+		border-radius: 2px;
+		background: linear-gradient(
+			90deg,
+			color-mix(in srgb, var(--color-ink) 88%, var(--lab-accent)),
+			color-mix(in srgb, var(--color-ink) 72%, var(--lab-accent)) 55%,
+			color-mix(in srgb, var(--color-ink) 92%, #000)
+		);
+		box-shadow: inset -2px 0 6px rgb(0 0 0 / 0.4);
+		overflow: hidden;
+	}
+
+	.spine-text {
+		writing-mode: vertical-rl;
+		font-family: var(--font-ui);
+		font-size: 0.62rem;
+		font-weight: 600;
+		letter-spacing: 0.02em;
+		color: color-mix(in srgb, var(--color-cream) 88%, transparent);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		max-height: 100%;
+	}
+
+	.spine-mark {
+		position: absolute;
+		left: 50%;
+		bottom: 10px;
+		width: 10px;
+		height: 10px;
+		border-radius: 999px;
+		background: var(--lab-accent);
+		transform: translateX(-50%);
+		opacity: 0.85;
+	}
+
+	// A hair of page block peeking out of the fore-edge.
+	.pages {
+		left: auto;
+		right: -3px;
+		width: 6px;
+		transform: rotateY(90deg);
+		transform-origin: right center;
+		background: repeating-linear-gradient(180deg, #efeade 0 1px, #dcd6c6 1px 2px);
+		border-radius: 0 3px 3px 0;
+	}
+
+	.plate {
+		position: absolute;
+		left: 50%;
+		top: -3.6rem;
+		display: grid;
+		gap: 0.15rem;
+		width: 168px;
+		padding: 0.5rem 0.6rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-md);
+		background: var(--color-surface);
+		box-shadow: var(--shadow-soft);
+		transform: translate(-50%, 8px);
+		opacity: 0;
+		pointer-events: none;
+		transition:
+			opacity 220ms ease,
+			transform 220ms ease;
+	}
+
+	.slot:hover .plate,
+	.slot:focus-visible .plate {
+		opacity: 1;
+		transform: translate(-50%, 0);
+	}
+
+	.plate-title {
+		font-family: var(--font-ui);
+		font-size: 0.8rem;
+		font-weight: 650;
+		line-height: 1.25;
+		color: var(--color-heading);
+	}
+
+	.plate-author {
+		font-size: 0.72rem;
+		color: var(--color-subtle);
+	}
+
+	.bar {
+		display: block;
+		height: 3px;
+		margin-top: 0.2rem;
+		border-radius: 999px;
+		background: var(--color-muted-strong);
+		overflow: hidden;
+	}
+
+	.bar-fill {
+		display: block;
+		height: 100%;
+		background: var(--lab-accent);
+	}
+
+	// The shelf board itself: a plank with a contact shadow above it.
+	.board {
+		height: 14px;
+		margin: -4px 0.5rem 0;
+		border-radius: 0 0 4px 4px;
+		background: linear-gradient(
+			180deg,
+			color-mix(in srgb, var(--color-ink) 26%, var(--color-muted-strong)),
+			color-mix(in srgb, var(--color-ink) 55%, var(--color-muted-strong))
+		);
+		box-shadow: 0 12px 24px -10px rgb(0 0 0 / 0.5);
+	}
+
+	.hint {
+		margin: 0.85rem 0 0;
+		padding-inline: 1.25rem;
+		font-size: 0.58rem;
+		color: var(--color-subtle);
+		opacity: 0.7;
+	}
+
+	@media (max-width: 600px) {
+		.plate {
+			width: 140px;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/CommandPalette.svelte
+++ b/personal-website/src/routes/lab/concepts/CommandPalette.svelte
@@ -1,0 +1,595 @@
+<script lang="ts">
+	import { onMount, tick } from 'svelte';
+	import { articles, bookNotes, photoTrips, siteSettings } from '$lib/content';
+
+	type Item = {
+		id: string;
+		group: 'Pages' | 'Book notes' | 'Photography' | 'Writing' | 'Actions';
+		label: string;
+		hint?: string;
+		icon: string;
+		href?: string;
+		run?: () => void;
+		/** Extra text folded into the match, never shown. */
+		keywords?: string;
+	};
+
+	type Scored = Item & { score: number; matched: number[] };
+
+	let open = $state(false);
+	let query = $state('');
+	let active = $state(0);
+	let input = $state<HTMLInputElement>();
+	let listEl = $state<HTMLDivElement>();
+	let announce = $state('');
+
+	const items: Item[] = [
+		...siteSettings.nav.map((link) => ({
+			id: `nav:${link.href}`,
+			group: 'Pages' as const,
+			label: link.label,
+			hint: link.href,
+			icon: link.icon,
+			href: link.href
+		})),
+		{
+			id: 'nav:/',
+			group: 'Pages',
+			label: 'Home',
+			hint: '/',
+			icon: 'cottage',
+			href: '/'
+		},
+		...bookNotes.map((book) => ({
+			id: `book:${book.slug}`,
+			group: 'Book notes' as const,
+			label: book.title,
+			hint: book.author,
+			icon: 'menu_book',
+			href: `/booknotes/${book.slug}`,
+			keywords: `${book.author} ${book.rating} ${book.published}`
+		})),
+		...photoTrips.map((trip) => ({
+			id: `trip:${trip.slug}`,
+			group: 'Photography' as const,
+			label: trip.title,
+			hint: `${trip.subtitle} · ${trip.year}`,
+			icon: 'photo_camera',
+			href: `/photography/${trip.slug}`,
+			keywords: `${trip.subtitle} ${trip.year}`
+		})),
+		...articles.map((article) => ({
+			id: `article:${article.slug}`,
+			group: 'Writing' as const,
+			label: article.title,
+			hint: article.published,
+			icon: 'edit_note',
+			href: `/writing/${article.slug}`,
+			keywords: article.description
+		})),
+		{
+			id: 'action:theme',
+			group: 'Actions',
+			label: 'Toggle dark mode',
+			hint: 'appearance',
+			icon: 'dark_mode',
+			keywords: 'light theme night',
+			run: () => {
+				const root = document.documentElement;
+				const next = root.dataset.theme === 'dark' ? 'light' : 'dark';
+				root.dataset.theme = next;
+				localStorage.setItem('theme', next);
+			}
+		},
+		{
+			id: 'action:case',
+			group: 'Actions',
+			label: 'Toggle lowercase mode',
+			hint: 'typography',
+			icon: 'text_fields',
+			keywords: 'caps casing',
+			run: () => {
+				const root = document.documentElement;
+				root.dataset.case = root.dataset.case === 'lower' ? 'normal' : 'lower';
+			}
+		},
+		{
+			id: 'action:email',
+			group: 'Actions',
+			label: 'Copy email address',
+			hint: siteSettings.email,
+			icon: 'content_copy',
+			keywords: 'contact mail reach out',
+			run: () => {
+				void navigator.clipboard?.writeText(siteSettings.email);
+				announce = 'Email copied to clipboard';
+			}
+		},
+		{
+			id: 'action:random-book',
+			group: 'Actions',
+			label: 'Surprise me with a book note',
+			hint: 'random',
+			icon: 'casino',
+			keywords: 'lucky shuffle',
+			run: () => {
+				const pick = bookNotes[Math.floor(Math.random() * bookNotes.length)];
+				if (pick) window.location.assign(`/booknotes/${pick.slug}`);
+			}
+		}
+	];
+
+	/**
+	 * Subsequence match with a bonus for hits at word starts and for runs of
+	 * adjacent characters, so `bth` ranks "Born To Run" above "Breath".
+	 * Returns the matched indices too, for highlighting.
+	 */
+	function score(text: string, needle: string): { score: number; matched: number[] } | null {
+		const haystack = text.toLowerCase();
+		let cursor = 0;
+		let total = 0;
+		let run = 0;
+		const matched: number[] = [];
+
+		for (const char of needle) {
+			const at = haystack.indexOf(char, cursor);
+			if (at === -1) return null;
+
+			const startsWord = at === 0 || /[\s\-/·:]/.test(haystack[at - 1] ?? '');
+			run = at === cursor ? run + 1 : 0;
+			total += 1 + run * 2 + (startsWord ? 4 : 0);
+			// Earlier matches are worth marginally more.
+			total += Math.max(0, 6 - at) * 0.2;
+
+			matched.push(at);
+			cursor = at + 1;
+		}
+
+		return { score: total, matched };
+	}
+
+	const results = $derived.by((): Scored[] => {
+		const needle = query.trim().toLowerCase();
+		if (!needle) {
+			return items
+				.filter((item) => item.group === 'Pages' || item.group === 'Actions')
+				.map((item) => ({ ...item, score: 0, matched: [] }));
+		}
+
+		const scored: Scored[] = [];
+		for (const item of items) {
+			const primary = score(item.label, needle);
+			const secondary = primary
+				? null
+				: score(`${item.label} ${item.hint ?? ''} ${item.keywords ?? ''}`, needle);
+			if (primary) scored.push({ ...item, score: primary.score, matched: primary.matched });
+			else if (secondary) scored.push({ ...item, score: secondary.score * 0.4, matched: [] });
+		}
+
+		return scored.sort((a, b) => b.score - a.score).slice(0, 12);
+	});
+
+	const grouped = $derived.by(() => {
+		const order: Item['group'][] = ['Pages', 'Writing', 'Book notes', 'Photography', 'Actions'];
+		const map = new Map<Item['group'], Scored[]>();
+		for (const item of results) {
+			const bucket = map.get(item.group) ?? [];
+			bucket.push(item);
+			map.set(item.group, bucket);
+		}
+		return order.filter((key) => map.has(key)).map((key) => ({ key, items: map.get(key)! }));
+	});
+
+	/** Flat, in-render order — this is what the arrow keys walk. */
+	const flat = $derived(grouped.flatMap((group) => group.items));
+
+	function highlight(label: string, matched: number[]) {
+		if (!matched.length) return [{ text: label, hit: false }];
+		const set = new Set(matched);
+		const parts: { text: string; hit: boolean }[] = [];
+		for (let i = 0; i < label.length; i++) {
+			const hit = set.has(i);
+			const last = parts[parts.length - 1];
+			if (last && last.hit === hit) last.text += label[i];
+			else parts.push({ text: label[i], hit });
+		}
+		return parts;
+	}
+
+	async function show() {
+		open = true;
+		query = '';
+		active = 0;
+		await tick();
+		input?.focus();
+	}
+
+	function hide() {
+		open = false;
+	}
+
+	function choose(item: Scored | undefined) {
+		if (!item) return;
+		hide();
+		if (item.run) item.run();
+		else if (item.href) window.location.assign(item.href);
+	}
+
+	function onKeydown(event: KeyboardEvent) {
+		if (event.key === 'Escape') {
+			hide();
+			return;
+		}
+		if (event.key === 'ArrowDown' || (event.key === 'n' && event.ctrlKey)) {
+			event.preventDefault();
+			active = flat.length ? (active + 1) % flat.length : 0;
+		} else if (event.key === 'ArrowUp' || (event.key === 'p' && event.ctrlKey)) {
+			event.preventDefault();
+			active = flat.length ? (active - 1 + flat.length) % flat.length : 0;
+		} else if (event.key === 'Enter') {
+			event.preventDefault();
+			choose(flat[active]);
+		}
+	}
+
+	// Keep the highlighted row inside the scroll viewport.
+	$effect(() => {
+		if (!open) return;
+		const id = flat[active]?.id;
+		if (!id) return;
+		listEl?.querySelector<HTMLElement>(`[data-id="${CSS.escape(id)}"]`)?.scrollIntoView({
+			block: 'nearest'
+		});
+	});
+
+	// Clamp the cursor whenever the result set shrinks under it.
+	$effect(() => {
+		if (active >= flat.length) active = 0;
+	});
+
+	onMount(() => {
+		function global(event: KeyboardEvent) {
+			if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'k') {
+				event.preventDefault();
+				if (open) hide();
+				else void show();
+			}
+		}
+		window.addEventListener('keydown', global);
+		return () => window.removeEventListener('keydown', global);
+	});
+</script>
+
+<div class="demo">
+	<button class="trigger" type="button" onclick={show}>
+		<span class="material-symbols-rounded" aria-hidden="true">search</span>
+		<span class="trigger-label">Search everything…</span>
+		<kbd data-preserve-case>⌘K</kbd>
+	</button>
+	<p class="caption">
+		One index over pages, {bookNotes.length} book notes, {photoTrips.length} trips and site actions. Fuzzy
+		matched — try <code>btr</code> or <code>dark</code>.
+	</p>
+</div>
+
+<span class="sr-only" role="status" aria-live="polite">{announce}</span>
+
+{#if open}
+	<div class="scrim">
+		<!-- A real button rather than a click handler on the backdrop: dismissing
+		     by clicking outside is then reachable by keyboard and screen readers. -->
+		<button class="scrim-close" type="button" aria-label="Close search" onclick={hide}></button>
+		<div
+			class="palette"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Site search"
+			tabindex="-1"
+			onkeydown={onKeydown}
+		>
+			<div class="field">
+				<span class="material-symbols-rounded" aria-hidden="true">search</span>
+				<input
+					bind:this={input}
+					bind:value={query}
+					onkeydown={onKeydown}
+					type="text"
+					placeholder="Search pages, books, trips, actions"
+					aria-label="Search"
+					autocomplete="off"
+					spellcheck="false"
+				/>
+				<kbd data-preserve-case>esc</kbd>
+			</div>
+
+			<div class="list" bind:this={listEl}>
+				{#if !flat.length}
+					<p class="empty">No matches for &ldquo;{query}&rdquo;.</p>
+				{/if}
+				{#each grouped as group (group.key)}
+					<p class="group lab-mono">{group.key}</p>
+					{#each group.items as item (item.id)}
+						{@const index = flat.indexOf(item)}
+						<button
+							class="row"
+							class:active={index === active}
+							type="button"
+							data-id={item.id}
+							onmouseenter={() => (active = index)}
+							onclick={() => choose(item)}
+						>
+							<span class="material-symbols-rounded row-icon" aria-hidden="true">{item.icon}</span>
+							<span class="row-label" data-preserve-case>
+								{#each highlight(item.label, item.matched) as part, i (i)}
+									{#if part.hit}<mark>{part.text}</mark>{:else}{part.text}{/if}
+								{/each}
+							</span>
+							{#if item.hint}
+								<span class="row-hint">{item.hint}</span>
+							{/if}
+							<span class="material-symbols-rounded row-go" aria-hidden="true">
+								{item.run ? 'bolt' : 'subdirectory_arrow_left'}
+							</span>
+						</button>
+					{/each}
+				{/each}
+			</div>
+
+			<div class="foot lab-mono">
+				<span><kbd data-preserve-case>↑↓</kbd> navigate</span>
+				<span><kbd data-preserve-case>↵</kbd> open</span>
+				<span><kbd data-preserve-case>esc</kbd> close</span>
+			</div>
+		</div>
+	</div>
+{/if}
+
+<style lang="scss">
+	.demo {
+		display: grid;
+		gap: 0.75rem;
+		justify-items: start;
+	}
+
+	.trigger {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.6rem;
+		width: min(420px, 100%);
+		padding: 0.7rem 0.75rem 0.7rem 0.85rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 999px;
+		background: var(--color-surface);
+		color: var(--color-subtle);
+		box-shadow: var(--shadow-subtle);
+		transition:
+			border-color var(--duration-fast) ease,
+			transform var(--duration-fast) ease;
+	}
+
+	.trigger:hover {
+		border-color: color-mix(in srgb, var(--lab-accent) 50%, transparent);
+		transform: translateY(-1px);
+	}
+
+	.trigger .material-symbols-rounded {
+		font-size: 1.15rem;
+		color: var(--lab-accent);
+	}
+
+	.trigger-label {
+		flex: 1;
+		text-align: left;
+		font-size: 0.92rem;
+	}
+
+	kbd {
+		font-family: var(--lab-mono);
+		font-size: 0.65rem;
+		padding: 0.16rem 0.38rem;
+		border: 1px solid var(--lab-hairline);
+		border-bottom-width: 2px;
+		border-radius: var(--radius-sm);
+		background: var(--color-muted);
+		color: var(--color-subtle);
+	}
+
+	.caption {
+		margin: 0;
+		max-width: 56ch;
+		font-size: 0.85rem;
+		color: var(--color-subtle);
+	}
+
+	.caption code {
+		font-family: var(--lab-mono);
+		font-size: 0.85em;
+		padding: 0.1em 0.35em;
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--color-ink) 8%, transparent);
+	}
+
+	.scrim-close {
+		position: absolute;
+		inset: 0;
+		border: none;
+		background: none;
+		cursor: default;
+	}
+
+	.scrim {
+		position: fixed;
+		inset: 0;
+		z-index: 200;
+		display: grid;
+		align-items: start;
+		justify-items: center;
+		padding: clamp(1rem, 12vh, 8rem) 1rem 1rem;
+		background: color-mix(in srgb, var(--color-ink) 42%, transparent);
+		backdrop-filter: blur(6px);
+		animation: fade 160ms ease;
+	}
+
+	.palette {
+		position: relative;
+		display: grid;
+		width: min(560px, 100%);
+		max-height: min(60vh, 520px);
+		grid-template-rows: auto 1fr auto;
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-lg);
+		background: var(--color-surface);
+		box-shadow: 0 30px 80px rgb(0 0 0 / 0.28);
+		overflow: hidden;
+		animation: pop 180ms cubic-bezier(0.2, 0.9, 0.3, 1.2);
+	}
+
+	.field {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		padding: 0.85rem 0.9rem;
+		border-bottom: 1px solid var(--lab-hairline);
+	}
+
+	.field .material-symbols-rounded {
+		color: var(--lab-accent);
+	}
+
+	.field input {
+		flex: 1;
+		min-width: 0;
+		border: none;
+		background: none;
+		outline: none;
+		font-size: 1rem;
+	}
+
+	.list {
+		overflow-y: auto;
+		padding: 0.4rem;
+	}
+
+	.group {
+		margin: 0.6rem 0 0.3rem 0.6rem;
+		font-size: 0.58rem;
+		color: var(--color-subtle);
+		opacity: 0.75;
+	}
+
+	.row {
+		display: grid;
+		grid-template-columns: 1.25rem minmax(0, auto) minmax(0, 1fr) 1rem;
+		align-items: center;
+		gap: 0.65rem;
+		width: 100%;
+		padding: 0.55rem 0.6rem;
+		border: none;
+		border-radius: var(--radius-md);
+		background: none;
+		text-align: left;
+		color: var(--color-ink);
+	}
+
+	.row.active {
+		background: color-mix(in srgb, var(--lab-accent) 13%, transparent);
+	}
+
+	.row-icon {
+		font-size: 1.1rem;
+		color: var(--color-subtle);
+	}
+
+	.row.active .row-icon {
+		color: var(--lab-accent);
+	}
+
+	.row-label {
+		font-size: 0.94rem;
+		font-weight: 500;
+		color: var(--color-heading);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.row-label mark {
+		background: none;
+		color: var(--lab-accent);
+		font-weight: 700;
+	}
+
+	.row-hint {
+		font-size: 0.76rem;
+		color: var(--color-subtle);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.row-go {
+		font-size: 0.9rem;
+		color: var(--color-subtle);
+		opacity: 0;
+	}
+
+	.row.active .row-go {
+		opacity: 0.8;
+	}
+
+	.empty {
+		margin: 1.5rem 0.6rem;
+		font-size: 0.9rem;
+		color: var(--color-subtle);
+	}
+
+	.foot {
+		display: flex;
+		gap: 1rem;
+		padding: 0.6rem 0.85rem;
+		border-top: 1px solid var(--lab-hairline);
+		background: var(--color-muted);
+		font-size: 0.58rem;
+		color: var(--color-subtle);
+	}
+
+	.foot span {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+	}
+
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		padding: 0;
+		margin: -1px;
+		overflow: hidden;
+		clip-path: inset(50%);
+		white-space: nowrap;
+	}
+
+	@keyframes fade {
+		from {
+			opacity: 0;
+		}
+	}
+
+	@keyframes pop {
+		from {
+			opacity: 0;
+			transform: translateY(-10px) scale(0.98);
+		}
+	}
+
+	@media (max-width: 560px) {
+		.row {
+			grid-template-columns: 1.25rem minmax(0, 1fr) 1rem;
+		}
+
+		.row-hint {
+			display: none;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/ConceptFrame.svelte
+++ b/personal-website/src/routes/lab/concepts/ConceptFrame.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	type Props = {
+		id: string;
+		index: number;
+		title: string;
+		tagline: string;
+		tags?: string[];
+		/** Where the concept would live on the real site. */
+		slot?: string;
+		/** Let the demo run edge to edge instead of sitting inside the panel gutter. */
+		bleed?: boolean;
+		/** Drop the panel chrome entirely (for demos that are their own surface). */
+		bare?: boolean;
+		children: Snippet;
+		notes?: Snippet;
+	};
+
+	let {
+		id,
+		index,
+		title,
+		tagline,
+		tags = [],
+		slot: placement,
+		bleed = false,
+		bare = false,
+		children,
+		notes
+	}: Props = $props();
+
+	const number = $derived(String(index).padStart(2, '0'));
+</script>
+
+<section class="frame" {id} aria-labelledby={`${id}-title`}>
+	<header class="head">
+		<div class="head-main">
+			<span class="number lab-mono" aria-hidden="true">{number}</span>
+			<div class="head-text">
+				<h2 id={`${id}-title`} data-preserve-case>{title}</h2>
+				<p class="tagline">{tagline}</p>
+			</div>
+		</div>
+		<div class="meta">
+			{#if placement}
+				<span class="lab-chip" data-tone="accent">{placement}</span>
+			{/if}
+			{#each tags as tag (tag)}
+				<span class="lab-chip">{tag}</span>
+			{/each}
+		</div>
+	</header>
+
+	<div class="stage" class:bleed class:bare>
+		{@render children()}
+	</div>
+
+	{#if notes}
+		<footer class="notes">
+			<span class="notes-label lab-mono">why</span>
+			<div class="notes-body">{@render notes()}</div>
+		</footer>
+	{/if}
+</section>
+
+<style lang="scss">
+	.frame {
+		scroll-margin-top: 1.5rem;
+		padding-block: clamp(2.5rem, 5vw, 4rem);
+		border-top: 1px solid var(--lab-hairline);
+	}
+
+	.head {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-start;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 1.35rem;
+	}
+
+	.head-main {
+		display: flex;
+		align-items: baseline;
+		gap: 0.9rem;
+		min-width: 0;
+	}
+
+	.number {
+		flex: 0 0 auto;
+		font-size: 0.72rem;
+		font-weight: 700;
+		color: var(--lab-accent);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.head-text {
+		min-width: 0;
+	}
+
+	h2 {
+		font-family: var(--font-ui);
+		font-size: clamp(1.25rem, 2.1vw, 1.6rem);
+		font-weight: 700;
+		letter-spacing: -0.03em;
+		margin: 0;
+	}
+
+	.tagline {
+		margin: 0.3rem 0 0;
+		max-width: 62ch;
+		color: var(--color-subtle);
+		font-size: 0.94rem;
+		line-height: 1.55;
+	}
+
+	.meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+		padding-top: 0.15rem;
+	}
+
+	.stage {
+		position: relative;
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-lg);
+		background: var(--lab-panel);
+		overflow: hidden;
+	}
+
+	.stage:not(.bleed):not(.bare) {
+		padding: clamp(1.1rem, 2.8vw, 2rem);
+	}
+
+	.stage.bare {
+		border: none;
+		background: none;
+		border-radius: 0;
+		overflow: visible;
+	}
+
+	.notes {
+		display: flex;
+		gap: 0.85rem;
+		margin-top: 1rem;
+		padding-left: 0.1rem;
+	}
+
+	.notes-label {
+		flex: 0 0 auto;
+		padding-top: 0.2rem;
+		font-size: 0.6rem;
+		color: var(--lab-accent);
+	}
+
+	.notes-body {
+		max-width: 70ch;
+		color: var(--color-subtle);
+		font-size: 0.88rem;
+		line-height: 1.6;
+	}
+
+	.notes-body :global(p) {
+		margin: 0;
+		font-size: inherit;
+		line-height: inherit;
+		color: inherit;
+	}
+
+	.notes-body :global(code) {
+		font-family: var(--lab-mono);
+		font-size: 0.85em;
+		padding: 0.1em 0.35em;
+		border-radius: var(--radius-sm);
+		background: color-mix(in srgb, var(--color-ink) 8%, transparent);
+	}
+
+	@media (max-width: 700px) {
+		.head-main {
+			gap: 0.6rem;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/Constellation.svelte
+++ b/personal-website/src/routes/lab/concepts/Constellation.svelte
@@ -1,0 +1,401 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	type Node = {
+		id: string;
+		label: string;
+		group: 'theme' | 'book' | 'place' | 'craft';
+		x: number;
+		y: number;
+		vx: number;
+		vy: number;
+		r: number;
+		href?: string;
+	};
+
+	type Link = { a: number; b: number };
+
+	const raw: { label: string; group: Node['group']; links: string[]; href?: string }[] = [
+		{ label: 'Attention', group: 'theme', links: [] },
+		{ label: 'Essentialism', group: 'book', links: ['Attention'], href: '/booknotes/essentialism' },
+		{ label: 'Deep Work', group: 'book', links: ['Attention'] },
+		{ label: 'Endurance', group: 'theme', links: [] },
+		{ label: 'Born To Run', group: 'book', links: ['Endurance'], href: '/booknotes/borntorun' },
+		{ label: 'Trail running', group: 'craft', links: ['Endurance'] },
+		{ label: 'Seeing', group: 'theme', links: [] },
+		{ label: 'Photography', group: 'craft', links: ['Seeing'], href: '/photography' },
+		{ label: 'Sydney', group: 'place', links: ['Photography'], href: '/photography/sydney25' },
+		{ label: 'Japan', group: 'place', links: ['Photography'] },
+		{ label: 'Melbourne', group: 'place', links: ['Photography', 'Trail running'] },
+		{ label: 'Making', group: 'theme', links: [] },
+		{ label: 'SvelteKit', group: 'craft', links: ['Making'] },
+		{ label: 'Typography', group: 'craft', links: ['Making', 'Seeing'] },
+		{
+			label: 'This site',
+			group: 'craft',
+			links: ['SvelteKit', 'Typography', 'Making'],
+			href: '/2026'
+		}
+	];
+
+	let canvas = $state<HTMLCanvasElement>();
+	let wrap = $state<HTMLDivElement>();
+	let hoveredLabel = $state<string | null>(null);
+
+	onMount(() => {
+		const el = canvas;
+		const host = wrap;
+		if (!el || !host) return;
+		const ctx = el.getContext('2d');
+		if (!ctx) return;
+
+		const index = new Map(raw.map((item, i) => [item.label, i]));
+		const links: Link[] = [];
+		raw.forEach((item, i) => {
+			for (const target of item.links) {
+				const j = index.get(target);
+				if (j != null) links.push({ a: i, b: j });
+			}
+		});
+
+		let width = 0;
+		let height = 0;
+		let dpr = 1;
+
+		const nodes: Node[] = raw.map((item) => ({
+			id: item.label,
+			label: item.label,
+			group: item.group,
+			x: Math.random(),
+			y: Math.random(),
+			vx: 0,
+			vy: 0,
+			r: item.group === 'theme' ? 30 : 13,
+			href: item.href
+		}));
+
+		function resize() {
+			const rect = host!.getBoundingClientRect();
+			dpr = Math.min(2, window.devicePixelRatio || 1);
+			width = rect.width;
+			height = rect.height;
+			el!.width = Math.round(width * dpr);
+			el!.height = Math.round(height * dpr);
+			ctx!.setTransform(dpr, 0, 0, dpr, 0, 0);
+		}
+
+		resize();
+		// Seed positions across the box once the size is known.
+		for (const node of nodes) {
+			node.x = width * (0.15 + Math.random() * 0.7);
+			node.y = height * (0.15 + Math.random() * 0.7);
+		}
+
+		const ro = new ResizeObserver(resize);
+		ro.observe(host);
+
+		let pointer = { x: -9999, y: -9999 };
+		let hovered: Node | null = null;
+
+		function onMove(event: PointerEvent) {
+			const rect = el!.getBoundingClientRect();
+			pointer = { x: event.clientX - rect.left, y: event.clientY - rect.top };
+		}
+		function onLeave() {
+			pointer = { x: -9999, y: -9999 };
+		}
+		function onClick() {
+			if (hovered?.href) window.location.assign(hovered.href);
+		}
+
+		host.addEventListener('pointermove', onMove);
+		host.addEventListener('pointerleave', onLeave);
+		host.addEventListener('click', onClick);
+
+		function palette() {
+			const styles = getComputedStyle(host!);
+			return {
+				accent: styles.getPropertyValue('--lab-accent').trim() || '#00ab44',
+				ink: styles.getPropertyValue('--color-heading').trim() || '#0c100e',
+				subtle: styles.getPropertyValue('--color-subtle').trim() || '#4d524f',
+				line: styles.getPropertyValue('--lab-hairline').trim() || 'rgba(0,0,0,0.14)',
+				surface: styles.getPropertyValue('--color-surface').trim() || '#fff'
+			};
+		}
+		let colours = palette();
+		const themeObserver = new MutationObserver(() => (colours = palette()));
+		themeObserver.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ['data-theme']
+		});
+
+		let raf = 0;
+		let visible = true;
+		const io = new IntersectionObserver(
+			([entry]) => {
+				visible = entry.isIntersecting;
+				if (visible && !raf) raf = requestAnimationFrame(step);
+			},
+			{ threshold: 0 }
+		);
+		io.observe(host);
+
+		const neighbours = new Map<number, Set<number>>();
+		for (const { a, b } of links) {
+			if (!neighbours.has(a)) neighbours.set(a, new Set());
+			if (!neighbours.has(b)) neighbours.set(b, new Set());
+			neighbours.get(a)!.add(b);
+			neighbours.get(b)!.add(a);
+		}
+
+		function simulate() {
+			// Repulsion between every pair, spring along every link, and a weak pull
+			// to the centre so the graph cannot drift out of frame.
+			for (let i = 0; i < nodes.length; i++) {
+				const a = nodes[i];
+				for (let j = i + 1; j < nodes.length; j++) {
+					const b = nodes[j];
+					const dx = b.x - a.x;
+					const dy = b.y - a.y;
+					const distance = Math.max(a.r + b.r, Math.hypot(dx, dy));
+					const force = ((a.r + b.r) * 105) / (distance * distance);
+					const fx = (dx / distance) * force;
+					const fy = (dy / distance) * force;
+					a.vx -= fx;
+					a.vy -= fy;
+					b.vx += fx;
+					b.vy += fy;
+				}
+			}
+
+			for (const { a, b } of links) {
+				const p = nodes[a];
+				const q = nodes[b];
+				const dx = q.x - p.x;
+				const dy = q.y - p.y;
+				const distance = Math.max(1, Math.hypot(dx, dy));
+				const force = (distance - 124) * 0.008;
+				const fx = (dx / distance) * force;
+				const fy = (dy / distance) * force;
+				p.vx += fx;
+				p.vy += fy;
+				q.vx -= fx;
+				q.vy -= fy;
+			}
+
+			for (const node of nodes) {
+				node.vx += (width / 2 - node.x) * 0.0016;
+				node.vy += (height / 2 - node.y) * 0.0016;
+
+				// The cursor gently pushes nodes aside, which makes the graph feel
+				// like a physical object rather than a picture.
+				const dx = node.x - pointer.x;
+				const dy = node.y - pointer.y;
+				const distance = Math.hypot(dx, dy);
+				if (distance < 120) {
+					const push = (120 - distance) * 0.012;
+					node.vx += (dx / Math.max(1, distance)) * push;
+					node.vy += (dy / Math.max(1, distance)) * push;
+				}
+
+				node.vx *= 0.86;
+				node.vy *= 0.86;
+				node.x = Math.min(width - node.r - 4, Math.max(node.r + 4, node.x + node.vx));
+				node.y = Math.min(height - node.r - 4, Math.max(node.r + 4, node.y + node.vy));
+			}
+		}
+
+		function draw() {
+			if (!ctx) return;
+			ctx.clearRect(0, 0, width, height);
+
+			hovered = null;
+			let hoveredIndex = -1;
+			for (let i = 0; i < nodes.length; i++) {
+				const node = nodes[i];
+				if (Math.hypot(node.x - pointer.x, node.y - pointer.y) < node.r + 6) {
+					hovered = node;
+					hoveredIndex = i;
+				}
+			}
+			hoveredLabel = hovered?.label ?? null;
+			el!.style.cursor = hovered?.href ? 'pointer' : 'default';
+
+			const lit = hoveredIndex >= 0 ? neighbours.get(hoveredIndex) : null;
+
+			ctx.lineWidth = 1;
+			for (const { a, b } of links) {
+				const on = hoveredIndex < 0 || a === hoveredIndex || b === hoveredIndex;
+				ctx.strokeStyle = on ? colours.accent : colours.line;
+				ctx.globalAlpha = on ? (hoveredIndex < 0 ? 0.32 : 0.85) : 0.12;
+				ctx.beginPath();
+				ctx.moveTo(nodes[a].x, nodes[a].y);
+				ctx.lineTo(nodes[b].x, nodes[b].y);
+				ctx.stroke();
+			}
+			ctx.globalAlpha = 1;
+
+			for (let i = 0; i < nodes.length; i++) {
+				const node = nodes[i];
+				const active = hoveredIndex < 0 || i === hoveredIndex || lit?.has(i);
+				const isTheme = node.group === 'theme';
+
+				ctx.globalAlpha = active ? 1 : 0.25;
+
+				ctx.beginPath();
+				ctx.arc(node.x, node.y, node.r, 0, Math.PI * 2);
+				ctx.fillStyle = isTheme ? colours.accent : colours.surface;
+				ctx.fill();
+				ctx.lineWidth = 1.4;
+				ctx.strokeStyle = isTheme ? colours.accent : colours.line;
+				ctx.stroke();
+
+				if (i === hoveredIndex) {
+					ctx.beginPath();
+					ctx.arc(node.x, node.y, node.r + 6, 0, Math.PI * 2);
+					ctx.strokeStyle = colours.accent;
+					ctx.lineWidth = 1;
+					ctx.stroke();
+				}
+
+				ctx.textAlign = 'center';
+				ctx.textBaseline = 'middle';
+
+				if (isTheme) {
+					// Shrink to fit the disc rather than spilling outside it.
+					let size = 11;
+					ctx.font = `600 ${size}px 'Poppins', sans-serif`;
+					while (size > 7 && ctx.measureText(node.label).width > node.r * 1.7) {
+						size -= 0.5;
+						ctx.font = `600 ${size}px 'Poppins', sans-serif`;
+					}
+					ctx.fillStyle = '#fff';
+					ctx.fillText(node.label, node.x, node.y);
+				} else {
+					ctx.font = `500 10px 'Poppins', sans-serif`;
+					ctx.fillStyle = active ? colours.ink : colours.subtle;
+					ctx.fillText(node.label, node.x, node.y + node.r + 10);
+				}
+			}
+			ctx.globalAlpha = 1;
+		}
+
+		function step() {
+			raf = 0;
+			if (!visible) return;
+			simulate();
+			draw();
+			raf = requestAnimationFrame(step);
+		}
+
+		raf = requestAnimationFrame(step);
+
+		return () => {
+			host.removeEventListener('pointermove', onMove);
+			host.removeEventListener('pointerleave', onLeave);
+			host.removeEventListener('click', onClick);
+			ro.disconnect();
+			io.disconnect();
+			themeObserver.disconnect();
+			if (raf) cancelAnimationFrame(raf);
+		};
+	});
+</script>
+
+<div class="graph-wrap">
+	<div class="graph lab-grid-bg" bind:this={wrap}>
+		<canvas bind:this={canvas} aria-hidden="true"></canvas>
+		<span class="badge lab-mono">{hoveredLabel ?? 'what connects to what'}</span>
+	</div>
+
+	<ul class="key lab-mono">
+		<li><span class="dot theme"></span>theme</li>
+		<li><span class="dot other"></span>book · place · craft</li>
+		<li class="spacer">hover to isolate · click a lit node to open it</li>
+	</ul>
+</div>
+
+<p class="sr-only">
+	A force-directed map linking themes to the books, places and crafts on this site.
+</p>
+
+<style lang="scss">
+	.graph-wrap {
+		display: grid;
+		gap: 0.6rem;
+	}
+
+	.graph {
+		position: relative;
+		height: clamp(320px, 46vw, 440px);
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-md);
+		background-color: var(--color-surface);
+		overflow: hidden;
+	}
+
+	canvas {
+		display: block;
+		width: 100%;
+		height: 100%;
+	}
+
+	.badge {
+		position: absolute;
+		left: 0.7rem;
+		top: 0.65rem;
+		padding: 0.22rem 0.5rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--color-surface) 88%, transparent);
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+		pointer-events: none;
+	}
+
+	.key {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.9rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+	}
+
+	.key li {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+	}
+
+	.spacer {
+		margin-left: auto;
+		opacity: 0.65;
+	}
+
+	.dot {
+		width: 9px;
+		height: 9px;
+		border-radius: 999px;
+	}
+
+	.dot.theme {
+		background: var(--lab-accent);
+	}
+
+	.dot.other {
+		border: 1.4px solid var(--lab-hairline);
+		background: var(--color-surface);
+	}
+
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		overflow: hidden;
+		clip-path: inset(50%);
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/ContactSheet.svelte
+++ b/personal-website/src/routes/lab/concepts/ContactSheet.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+	import { photoTrips } from '$lib/content';
+
+	const strips = photoTrips.slice(0, 6).map((trip) => ({
+		slug: trip.slug,
+		title: trip.title,
+		subtitle: trip.subtitle,
+		year: trip.year,
+		images: trip.images.slice(0, 12)
+	}));
+
+	// One scrub index per strip, driven by pointer X across the frame.
+	let cursor = $state<Record<string, number>>(
+		Object.fromEntries(strips.map((strip) => [strip.slug, 0]))
+	);
+	let active = $state<string | null>(null);
+
+	function scrub(slug: string, count: number, event: PointerEvent) {
+		const frame = event.currentTarget as HTMLElement;
+		const rect = frame.getBoundingClientRect();
+		const ratio = Math.min(0.999, Math.max(0, (event.clientX - rect.left) / rect.width));
+		cursor = { ...cursor, [slug]: Math.floor(ratio * count) };
+		active = slug;
+	}
+</script>
+
+<div class="sheet">
+	{#each strips as strip (strip.slug)}
+		{@const index = cursor[strip.slug] ?? 0}
+		{@const shot = strip.images[index] ?? strip.images[0]}
+		<a
+			class="frame"
+			class:active={active === strip.slug}
+			href={`/photography/${strip.slug}`}
+			onpointermove={(event) => scrub(strip.slug, strip.images.length, event)}
+			onpointerleave={() => (active = null)}
+			aria-label={`${strip.title}, ${strip.subtitle} — ${strip.images.length} photographs`}
+		>
+			<span class="sprockets top" aria-hidden="true"></span>
+
+			<span class="window">
+				{#each strip.images as image, i (image.src)}
+					<img
+						src={image.src}
+						alt={i === 0 ? image.alt : ''}
+						class:showing={i === index}
+						loading="lazy"
+						decoding="async"
+					/>
+				{/each}
+				<span class="crosshair" aria-hidden="true"></span>
+				<span class="edge lab-mono" aria-hidden="true">
+					{strip.slug.toUpperCase()} · {String(index + 1).padStart(2, '0')}/{String(
+						strip.images.length
+					).padStart(2, '0')}
+				</span>
+			</span>
+
+			<span class="sprockets bottom" aria-hidden="true"></span>
+
+			<span class="caption">
+				<span class="where" data-preserve-case>{strip.title}</span>
+				<span class="what">{shot?.location ?? strip.subtitle}</span>
+				<span class="when lab-mono">{shot?.capturedAtLabel ?? strip.year}</span>
+			</span>
+
+			<span class="scrub" aria-hidden="true">
+				{#each strip.images as image, i (image.src)}
+					<span class="tick" class:on={i <= index}></span>
+				{/each}
+			</span>
+		</a>
+	{/each}
+</div>
+
+<p class="hint lab-mono">sweep across a frame to scrub the roll</p>
+
+<style lang="scss">
+	.sheet {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(240px, 100%), 1fr));
+		gap: clamp(0.75rem, 2vw, 1.25rem);
+	}
+
+	.frame {
+		position: relative;
+		display: grid;
+		gap: 0;
+		padding: 0.35rem 0;
+		border-radius: 4px;
+		background: #16181a;
+		text-decoration: none;
+		color: #e9e6df;
+		overflow: hidden;
+		transition:
+			transform 300ms cubic-bezier(0.2, 0.9, 0.3, 1.1),
+			box-shadow 300ms ease;
+	}
+
+	.frame.active {
+		transform: translateY(-4px) scale(1.012);
+		box-shadow: 0 18px 40px -18px rgb(0 0 0 / 0.65);
+	}
+
+	// 35mm perforations along the top and bottom of the strip.
+	.sprockets {
+		height: 12px;
+		background-image: radial-gradient(circle at 8px 50%, #0b0c0d 0 3.2px, transparent 3.4px);
+		background-size: 20px 12px;
+		background-repeat: repeat-x;
+		opacity: 0.9;
+	}
+
+	.window {
+		position: relative;
+		aspect-ratio: 3 / 2;
+		overflow: hidden;
+		background: #0b0c0d;
+	}
+
+	.window img {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		opacity: 0;
+		// No cross-fade: scrubbing should feel like advancing frames, not
+		// dissolving between them.
+		transition: opacity 60ms linear;
+	}
+
+	.window img.showing {
+		opacity: 1;
+	}
+
+	.crosshair {
+		position: absolute;
+		inset: 8px;
+		border: 1px solid rgb(255 255 255 / 0.16);
+		opacity: 0;
+		transition: opacity 200ms ease;
+	}
+
+	.frame.active .crosshair {
+		opacity: 1;
+	}
+
+	.edge {
+		position: absolute;
+		right: 8px;
+		bottom: 6px;
+		padding: 0.12rem 0.35rem;
+		border-radius: 2px;
+		background: rgb(0 0 0 / 0.5);
+		font-size: 0.52rem;
+		letter-spacing: 0.16em;
+		color: #ffb347;
+	}
+
+	.caption {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		align-items: baseline;
+		gap: 0.15rem 0.6rem;
+		padding: 0.55rem 0.7rem 0.4rem;
+	}
+
+	.where {
+		grid-column: 1;
+		font-family: var(--font-ui);
+		font-size: 0.92rem;
+		font-weight: 650;
+		letter-spacing: -0.01em;
+	}
+
+	.what {
+		grid-column: 1;
+		grid-row: 2;
+		font-size: 0.76rem;
+		color: rgb(233 230 223 / 0.6);
+	}
+
+	.when {
+		grid-column: 2;
+		grid-row: 1 / span 2;
+		font-size: 0.56rem;
+		color: rgb(233 230 223 / 0.45);
+	}
+
+	.scrub {
+		display: flex;
+		gap: 2px;
+		padding: 0 0.7rem 0.55rem;
+	}
+
+	.tick {
+		flex: 1;
+		height: 2px;
+		border-radius: 999px;
+		background: rgb(255 255 255 / 0.14);
+		transition: background 120ms linear;
+	}
+
+	.tick.on {
+		background: var(--lab-accent);
+	}
+
+	.hint {
+		margin: 1rem 0 0;
+		font-size: 0.58rem;
+		color: var(--color-subtle);
+		opacity: 0.7;
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/ElasticNav.svelte
+++ b/personal-website/src/routes/lab/concepts/ElasticNav.svelte
@@ -1,0 +1,215 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	type Props = { options?: string[] };
+	let { options = ['All', 'Photography', 'Book notes', 'Writing', 'Projects'] }: Props = $props();
+
+	let selected = $state(0);
+	let hovered = $state<number | null>(null);
+	let list = $state<HTMLDivElement>();
+	let indicator = $state<HTMLSpanElement>();
+	let buttons: HTMLButtonElement[] = [];
+
+	onMount(() => {
+		if (!list || !indicator) return;
+
+		// A tiny critically-under-damped spring. The overshoot is the whole point:
+		// a CSS transition arrives politely, a spring arrives with momentum, and
+		// the squash is read straight off its velocity.
+		const STIFFNESS = 0.16;
+		const DAMPING = 0.74;
+
+		let x = 0;
+		let vx = 0;
+		let w = 0;
+		let vw = 0;
+		let raf = 0;
+		let settled = false;
+
+		function targetFor(index: number) {
+			const button = buttons[index];
+			if (!button) return null;
+			return { x: button.offsetLeft, w: button.offsetWidth };
+		}
+
+		function frame() {
+			raf = 0;
+			// Hovering leans the pill part-way toward the hovered item without
+			// committing to it — the nav acknowledges the cursor before the click.
+			const base = targetFor(selected);
+			const lean = hovered != null ? targetFor(hovered) : null;
+			if (!base) return;
+
+			const target = lean
+				? { x: base.x + (lean.x - base.x) * 0.22, w: base.w + (lean.w - base.w) * 0.22 }
+				: base;
+
+			vx = (vx + (target.x - x) * STIFFNESS) * DAMPING;
+			vw = (vw + (target.w - w) * STIFFNESS) * DAMPING;
+			x += vx;
+			w += vw;
+
+			// Squash along travel, stretch across it, conserving apparent volume.
+			const squash = Math.min(0.32, Math.abs(vx) / 62);
+
+			if (indicator) {
+				indicator.style.transform = `translate3d(${x.toFixed(2)}px,0,0) scale(${(
+					1 + squash
+				).toFixed(3)}, ${(1 - squash * 0.55).toFixed(3)})`;
+				indicator.style.width = `${w.toFixed(2)}px`;
+			}
+
+			settled = Math.abs(vx) < 0.02 && Math.abs(vw) < 0.02 && Math.abs(target.x - x) < 0.3;
+			if (!settled) raf = requestAnimationFrame(frame);
+		}
+
+		function kick() {
+			if (!raf) raf = requestAnimationFrame(frame);
+		}
+
+		const initial = targetFor(0);
+		if (initial) {
+			x = initial.x;
+			w = initial.w;
+			indicator.style.width = `${w}px`;
+			indicator.style.transform = `translate3d(${x}px,0,0)`;
+			indicator.style.opacity = '1';
+		}
+
+		// Any change to selection or hover restarts the spring.
+		const stop = $effect.root(() => {
+			$effect(() => {
+				void selected;
+				void hovered;
+				kick();
+			});
+		});
+
+		const ro = new ResizeObserver(kick);
+		ro.observe(list);
+
+		return () => {
+			stop();
+			ro.disconnect();
+			if (raf) cancelAnimationFrame(raf);
+		};
+	});
+
+	// Roving tabindex: the newly selected tab is the only tabbable one, so focus
+	// has to follow the selection or the keyboard user is left on a -1 element.
+	function onKeydown(event: KeyboardEvent) {
+		if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+		event.preventDefault();
+		const step = event.key === 'ArrowRight' ? 1 : -1;
+		selected = (selected + step + options.length) % options.length;
+		buttons[selected]?.focus();
+	}
+</script>
+
+<div class="nav-demo">
+	<div
+		class="segmented"
+		bind:this={list}
+		role="tablist"
+		aria-label="Filter"
+		tabindex="-1"
+		onmouseleave={() => (hovered = null)}
+	>
+		<span class="indicator" bind:this={indicator} aria-hidden="true"></span>
+		{#each options as option, i (option)}
+			<button
+				class="seg"
+				class:on={selected === i}
+				bind:this={buttons[i]}
+				type="button"
+				role="tab"
+				aria-selected={selected === i}
+				tabindex={selected === i ? 0 : -1}
+				onclick={() => (selected = i)}
+				onkeydown={onKeydown}
+				onmouseenter={() => (hovered = i)}
+				onfocus={() => (hovered = i)}
+			>
+				{option}
+			</button>
+		{/each}
+	</div>
+
+	<p class="echo">
+		Showing <b data-preserve-case>{options[selected]}</b> — arrow keys work too.
+	</p>
+</div>
+
+<style lang="scss">
+	.nav-demo {
+		display: grid;
+		gap: 0.9rem;
+		justify-items: start;
+	}
+
+	// Deliberately nowrap: the indicator is positioned from `offsetLeft` alone,
+	// so a wrapped second row would leave it stranded on the first.
+	.segmented {
+		position: relative;
+		display: flex;
+		flex-wrap: nowrap;
+		gap: 0.15rem;
+		max-width: 100%;
+		padding: 0.28rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 999px;
+		background: var(--color-muted);
+		overflow-x: auto;
+		scrollbar-width: none;
+	}
+
+	.segmented::-webkit-scrollbar {
+		display: none;
+	}
+
+	.indicator {
+		position: absolute;
+		top: 0.28rem;
+		left: 0;
+		height: calc(100% - 0.56rem);
+		border-radius: 999px;
+		background: var(--color-surface);
+		box-shadow: var(--shadow-subtle);
+		opacity: 0;
+		transform-origin: center;
+		will-change: transform, width;
+	}
+
+	.seg {
+		position: relative;
+		z-index: 1;
+		padding: 0.5rem 0.95rem;
+		border: none;
+		border-radius: 999px;
+		background: none;
+		font-family: var(--font-ui);
+		font-size: 0.85rem;
+		font-weight: 600;
+		color: var(--color-subtle);
+		white-space: nowrap;
+		transition: color 200ms ease;
+	}
+
+	.seg.on {
+		color: var(--color-heading);
+	}
+
+	.seg:hover {
+		color: var(--color-heading);
+	}
+
+	.echo {
+		margin: 0;
+		font-size: 0.88rem;
+		color: var(--color-subtle);
+	}
+
+	.echo b {
+		color: var(--lab-accent);
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/HorizontalRail.svelte
+++ b/personal-website/src/routes/lab/concepts/HorizontalRail.svelte
@@ -1,0 +1,285 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { photoTrips } from '$lib/content';
+
+	const steps = [
+		{
+			title: 'Walk',
+			body: 'Most of a trip is walking. The camera stays off until something is actually worth stopping for.',
+			icon: 'directions_walk'
+		},
+		{
+			title: 'Shoot',
+			body: 'One body, one lens. Constraints do more for a set of photographs than any amount of gear.',
+			icon: 'photo_camera'
+		},
+		{
+			title: 'Cull',
+			body: 'A few hundred frames become twenty. The hardest edit is the one that removes a photo you like.',
+			icon: 'filter_alt'
+		},
+		{
+			title: 'Develop',
+			body: 'Warm shadows, restrained contrast, colour left roughly where the day put it.',
+			icon: 'tune'
+		},
+		{
+			title: 'Publish',
+			body: 'Written up as a trip, dated, and put somewhere I can find it again in ten years.',
+			icon: 'ios_share'
+		}
+	].map((step, i) => ({ ...step, image: photoTrips[i]?.coverImage ?? photoTrips[0].coverImage }));
+
+	let outer = $state<HTMLDivElement>();
+	let sticky = $state<HTMLDivElement>();
+	let track = $state<HTMLDivElement>();
+	let progress = $state(0);
+
+	onMount(() => {
+		if (!outer || !track) return;
+
+		let raf = 0;
+		let distance = 0;
+
+		function measure() {
+			// How far the track has to travel for its right edge to reach the right
+			// edge of the pinned viewport. Measured against the sticky container
+			// rather than the window, so the section stays inside the page column.
+			distance = Math.max(0, (track?.scrollWidth ?? 0) - (sticky?.clientWidth ?? 0));
+		}
+
+		function update() {
+			raf = 0;
+			const rect = outer!.getBoundingClientRect();
+			const total = rect.height - window.innerHeight;
+			if (total <= 0) {
+				progress = 0;
+				return;
+			}
+			const p = Math.min(1, Math.max(0, -rect.top / total));
+			progress = p;
+			if (track) track.style.transform = `translate3d(${-p * distance}px, 0, 0)`;
+		}
+
+		function onScroll() {
+			if (!raf) raf = requestAnimationFrame(update);
+		}
+
+		measure();
+		update();
+
+		window.addEventListener('scroll', onScroll, { passive: true });
+		const ro = new ResizeObserver(() => {
+			measure();
+			update();
+		});
+		ro.observe(track);
+
+		return () => {
+			window.removeEventListener('scroll', onScroll);
+			ro.disconnect();
+			if (raf) cancelAnimationFrame(raf);
+		};
+	});
+</script>
+
+<div class="outer" bind:this={outer}>
+	<div class="sticky" bind:this={sticky}>
+		<div class="head">
+			<span class="lab-mono label">how a photograph gets here</span>
+			<div class="progress" aria-hidden="true">
+				<span class="progress-fill" style={`transform:scaleX(${progress})`}></span>
+			</div>
+			<span class="lab-mono count">
+				{String(Math.min(steps.length, Math.floor(progress * steps.length) + 1)).padStart(2, '0')}
+				/ {String(steps.length).padStart(2, '0')}
+			</span>
+		</div>
+
+		<div class="track" bind:this={track}>
+			{#each steps as step, i (step.title)}
+				<article class="panel">
+					<div class="panel-media">
+						<img src={step.image} alt="" loading="lazy" />
+						<span class="panel-index lab-mono">{String(i + 1).padStart(2, '0')}</span>
+					</div>
+					<div class="panel-copy">
+						<span class="material-symbols-rounded" aria-hidden="true">{step.icon}</span>
+						<h4 data-preserve-case>{step.title}</h4>
+						<p>{step.body}</p>
+					</div>
+				</article>
+			{/each}
+			<article class="panel end">
+				<div class="panel-copy">
+					<h4 data-preserve-case>That&rsquo;s the whole process.</h4>
+					<p>No presets for sale, no newsletter, no course.</p>
+					<a class="end-link" href="/photography">
+						Go to the galleries
+						<span class="material-symbols-rounded" aria-hidden="true">arrow_forward</span>
+					</a>
+				</div>
+			</article>
+		</div>
+	</div>
+</div>
+
+<style lang="scss">
+	// The outer block's height is what the horizontal travel is spent against;
+	// 300vh gives roughly one screen of scroll per two panels.
+	.outer {
+		height: 320vh;
+	}
+
+	.sticky {
+		position: sticky;
+		top: 0;
+		display: grid;
+		grid-template-rows: auto 1fr;
+		align-content: center;
+		gap: 1.25rem;
+		height: 100vh;
+		padding-block: clamp(1.5rem, 5vh, 3rem);
+		overflow: hidden;
+	}
+
+	.head {
+		display: flex;
+		align-items: center;
+		gap: 0.9rem;
+		width: 100%;
+	}
+
+	.label,
+	.count {
+		flex: 0 0 auto;
+		font-size: 0.56rem;
+		color: var(--color-subtle);
+	}
+
+	.progress {
+		flex: 1;
+		height: 2px;
+		border-radius: 999px;
+		background: var(--lab-hairline);
+		overflow: hidden;
+	}
+
+	.progress-fill {
+		display: block;
+		height: 100%;
+		background: var(--lab-accent);
+		transform-origin: left center;
+		transform: scaleX(0);
+	}
+
+	.track {
+		display: flex;
+		align-items: center;
+		gap: clamp(1rem, 3vw, 2.5rem);
+		width: max-content;
+		padding-right: clamp(1rem, 4vw, 3rem);
+		will-change: transform;
+	}
+
+	.panel {
+		display: grid;
+		grid-template-columns: minmax(0, 260px) minmax(0, 300px);
+		gap: 1.5rem;
+		align-items: center;
+		width: clamp(290px, 52vw, 580px);
+	}
+
+	.panel-media {
+		position: relative;
+		aspect-ratio: 3 / 4;
+		border-radius: var(--radius-lg);
+		overflow: hidden;
+		background: var(--color-muted);
+		box-shadow: 0 20px 50px -28px rgb(0 0 0 / 0.6);
+	}
+
+	.panel-media img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+	}
+
+	.panel-index {
+		position: absolute;
+		left: 0.7rem;
+		top: 0.6rem;
+		padding: 0.15rem 0.45rem;
+		border-radius: var(--radius-sm);
+		background: rgb(0 0 0 / 0.5);
+		font-size: 0.55rem;
+		color: #fff;
+	}
+
+	.panel-copy {
+		display: grid;
+		gap: 0.5rem;
+		align-content: center;
+	}
+
+	.panel-copy .material-symbols-rounded {
+		font-size: 1.4rem;
+		color: var(--lab-accent);
+	}
+
+	.panel-copy h4 {
+		margin: 0;
+		font-family: var(--font-display);
+		font-size: clamp(1.6rem, 3.4vw, 2.4rem);
+		font-weight: 500;
+		letter-spacing: -0.03em;
+		line-height: 1.05;
+		font-variation-settings: 'SOFT' 40;
+	}
+
+	.panel-copy p {
+		margin: 0;
+		max-width: 34ch;
+		color: var(--color-subtle);
+		font-size: 0.95rem;
+		line-height: 1.6;
+	}
+
+	.end {
+		grid-template-columns: minmax(0, 1fr);
+		width: clamp(260px, 34vw, 420px);
+	}
+
+	.end-link {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		margin-top: 0.4rem;
+		font-family: var(--font-ui);
+		font-size: 0.9rem;
+		font-weight: 600;
+		color: var(--lab-accent);
+		text-decoration: none;
+	}
+
+	.end-link:hover .material-symbols-rounded {
+		transform: translateX(4px);
+	}
+
+	.end-link .material-symbols-rounded {
+		font-size: 1.05rem;
+		transition: transform var(--duration-fast) ease;
+	}
+
+	@media (max-width: 720px) {
+		.panel {
+			grid-template-columns: minmax(0, 1fr);
+			width: clamp(240px, 68vw, 340px);
+			gap: 1rem;
+		}
+
+		.panel-media {
+			aspect-ratio: 16 / 10;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/HoverPreviewList.svelte
+++ b/personal-website/src/routes/lab/concepts/HoverPreviewList.svelte
@@ -1,0 +1,231 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { bookNotes } from '$lib/content';
+
+	const rows = bookNotes.slice(0, 8);
+
+	let host = $state<HTMLDivElement>();
+	let floater = $state<HTMLDivElement>();
+	let hovered = $state<number | null>(null);
+
+	onMount(() => {
+		if (!host || !floater) return;
+
+		let targetX = 0;
+		let targetY = 0;
+		let x = 0;
+		let y = 0;
+		let raf = 0;
+		let last = 0;
+
+		function onMove(event: PointerEvent) {
+			const rect = host!.getBoundingClientRect();
+			targetX = event.clientX - rect.left;
+			targetY = event.clientY - rect.top;
+			if (!raf) raf = requestAnimationFrame(frame);
+		}
+
+		function frame() {
+			raf = 0;
+			// Lag behind the cursor, and tilt in proportion to how fast it is
+			// catching up — the preview reads as a physical card being dragged.
+			const dx = (targetX - x) * 0.16;
+			const dy = (targetY - y) * 0.16;
+			x += dx;
+			y += dy;
+			last = last * 0.8 + dx * 0.2;
+
+			floater!.style.transform = `translate3d(${x.toFixed(1)}px, ${y.toFixed(
+				1
+			)}px, 0) translate(-50%, -50%) rotate(${(last * 0.55).toFixed(2)}deg)`;
+
+			if (Math.abs(targetX - x) > 0.4 || Math.abs(targetY - y) > 0.4) {
+				raf = requestAnimationFrame(frame);
+			}
+		}
+
+		host.addEventListener('pointermove', onMove);
+		return () => {
+			host?.removeEventListener('pointermove', onMove);
+			if (raf) cancelAnimationFrame(raf);
+		};
+	});
+</script>
+
+<div class="list-wrap" bind:this={host} class:engaged={hovered !== null}>
+	<div class="floater" bind:this={floater} class:on={hovered !== null} aria-hidden="true">
+		{#each rows as book, i (book.slug)}
+			<img src={book.cover} alt="" class:showing={hovered === i} loading="lazy" />
+		{/each}
+	</div>
+
+	<ul>
+		{#each rows as book, i (book.slug)}
+			<li>
+				<a
+					href={`/booknotes/${book.slug}`}
+					class:lit={hovered === i}
+					onpointerenter={() => (hovered = i)}
+					onfocus={() => (hovered = i)}
+					onpointerleave={() => (hovered = null)}
+					onblur={() => (hovered = null)}
+				>
+					<span class="idx lab-mono">{String(i + 1).padStart(2, '0')}</span>
+					<span class="title" data-preserve-case>{book.title}</span>
+					<span class="author" data-preserve-case>{book.author}</span>
+					<span class="rating lab-mono">{book.rating}</span>
+					<span class="arrow material-symbols-rounded" aria-hidden="true">arrow_outward</span>
+				</a>
+			</li>
+		{/each}
+	</ul>
+</div>
+
+<style lang="scss">
+	.list-wrap {
+		position: relative;
+	}
+
+	ul {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+	}
+
+	li + li a {
+		border-top: 1px solid var(--lab-hairline);
+	}
+
+	a {
+		position: relative;
+		display: grid;
+		grid-template-columns: 2.25rem minmax(0, 1fr) minmax(0, 0.8fr) 3rem 1.25rem;
+		align-items: baseline;
+		gap: 1rem;
+		padding: 0.95rem 0.35rem;
+		text-decoration: none;
+		color: inherit;
+		transition:
+			opacity 260ms ease,
+			padding-left 320ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	// Everything recedes except the row under the cursor.
+	.list-wrap.engaged a {
+		opacity: 0.42;
+	}
+
+	.list-wrap.engaged a.lit {
+		opacity: 1;
+		padding-left: 1.1rem;
+	}
+
+	.idx {
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+	}
+
+	a.lit .idx {
+		color: var(--lab-accent);
+	}
+
+	.title {
+		font-family: var(--font-ui);
+		font-size: clamp(1rem, 1.8vw, 1.3rem);
+		font-weight: 600;
+		letter-spacing: -0.025em;
+		color: var(--color-heading);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.author {
+		font-size: 0.85rem;
+		color: var(--color-subtle);
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+	}
+
+	.rating {
+		font-size: 0.58rem;
+		color: var(--color-subtle);
+		text-align: right;
+		font-variant-numeric: tabular-nums;
+	}
+
+	.arrow {
+		font-size: 1rem;
+		color: var(--lab-accent);
+		opacity: 0;
+		transform: translateX(-6px);
+		transition:
+			opacity 220ms ease,
+			transform 220ms ease;
+	}
+
+	a.lit .arrow {
+		opacity: 1;
+		transform: none;
+	}
+
+	.floater {
+		position: absolute;
+		left: 0;
+		top: 0;
+		z-index: 4;
+		width: 132px;
+		height: 198px;
+		border-radius: var(--radius-md);
+		overflow: hidden;
+		box-shadow: 0 22px 50px -20px rgb(0 0 0 / 0.6);
+		pointer-events: none;
+		opacity: 0;
+		transition:
+			opacity 220ms ease,
+			scale 320ms cubic-bezier(0.2, 0.9, 0.3, 1.3);
+		scale: 0.85;
+		will-change: transform;
+	}
+
+	.floater.on {
+		opacity: 1;
+		scale: 1;
+	}
+
+	.floater img {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		opacity: 0;
+		transition: opacity 180ms ease;
+	}
+
+	.floater img.showing {
+		opacity: 1;
+	}
+
+	@media (hover: none) {
+		.floater {
+			display: none;
+		}
+
+		.list-wrap.engaged a {
+			opacity: 1;
+		}
+	}
+
+	@media (max-width: 640px) {
+		a {
+			grid-template-columns: 2rem minmax(0, 1fr) 3rem;
+		}
+
+		.author,
+		.arrow {
+			display: none;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/KineticMasthead.svelte
+++ b/personal-website/src/routes/lab/concepts/KineticMasthead.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	type Props = { word?: string; kicker?: string };
+	let { word = 'Groombridge', kicker = 'photographer / builder / reader' }: Props = $props();
+
+	const letters = $derived(word.split(''));
+
+	let stage = $state<HTMLDivElement>();
+	let spans: HTMLSpanElement[] = [];
+
+	/** Pointer position in stage space; `-1` means "no pointer, run the idle wave". */
+	let pointerX = -1;
+	let pointerY = 0;
+	let hovering = false;
+
+	// Per-letter eased state, filled lazily so it survives a change of `word`.
+	const current: number[] = [];
+	const target: number[] = [];
+
+	onMount(() => {
+		const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+		if (reduce) {
+			for (const span of spans) span?.style.setProperty('--k', '0.35');
+			return;
+		}
+
+		let raf = 0;
+		let running = true;
+		const start = performance.now();
+
+		const observer = new IntersectionObserver(
+			([entry]) => {
+				running = entry.isIntersecting;
+				if (running && !raf) raf = requestAnimationFrame(tick);
+			},
+			{ threshold: 0 }
+		);
+		if (stage) observer.observe(stage);
+
+		function tick(now: number) {
+			raf = 0;
+			if (!running) return;
+
+			const t = (now - start) / 1000;
+
+			for (let i = 0; i < spans.length; i++) {
+				const span = spans[i];
+				if (!span) continue;
+
+				if (hovering && pointerX >= 0) {
+					// Distance from the pointer to this glyph's centre, normalised by a
+					// falloff radius so nearby letters bloom and distant ones stay calm.
+					const box = span.offsetLeft + span.offsetWidth / 2;
+					const dx = (pointerX - box) / 190;
+					const dy = pointerY / 260;
+					target[i] = Math.max(0, 1 - Math.hypot(dx, dy));
+				} else {
+					// Idle: a slow wave travels along the word so it never sits dead.
+					target[i] = ((Math.sin(t * 1.5 - i * 0.42) + 1) / 2) * 0.45;
+				}
+
+				const at = current[i] ?? 0;
+				current[i] = at + (target[i] - at) * 0.14;
+				span.style.setProperty('--k', current[i].toFixed(4));
+			}
+
+			raf = requestAnimationFrame(tick);
+		}
+
+		raf = requestAnimationFrame(tick);
+
+		return () => {
+			observer.disconnect();
+			if (raf) cancelAnimationFrame(raf);
+		};
+	});
+
+	function onMove(event: PointerEvent) {
+		if (!stage) return;
+		const rect = stage.getBoundingClientRect();
+		pointerX = event.clientX - rect.left;
+		pointerY = event.clientY - rect.top - rect.height / 2;
+		hovering = true;
+	}
+
+	function onLeave() {
+		hovering = false;
+		pointerX = -1;
+	}
+</script>
+
+<div
+	class="stage lab-grain"
+	bind:this={stage}
+	onpointermove={onMove}
+	onpointerleave={onLeave}
+	role="presentation"
+>
+	<p class="kicker lab-mono">{kicker}</p>
+	<h3 class="word" aria-label={word}>
+		{#each letters as letter, i (i)}
+			<span class="letter" bind:this={spans[i]} aria-hidden="true">{letter}</span>
+		{/each}
+	</h3>
+	<div class="rule"><span class="rule-fill"></span></div>
+	<p class="hint lab-mono">move your cursor across the name</p>
+</div>
+
+<style lang="scss">
+	.stage {
+		position: relative;
+		display: grid;
+		gap: 0.9rem;
+		justify-items: start;
+		padding: clamp(1.5rem, 4vw, 3rem) clamp(0.5rem, 2vw, 1.5rem);
+		border-radius: var(--radius-md);
+		background:
+			radial-gradient(
+				120% 140% at 8% 0%,
+				color-mix(in srgb, var(--lab-accent) 12%, transparent),
+				transparent 62%
+			),
+			var(--color-surface);
+		overflow: hidden;
+		touch-action: pan-y;
+	}
+
+	.kicker,
+	.hint {
+		margin: 0;
+		font-size: 0.62rem;
+		color: var(--color-subtle);
+	}
+
+	.hint {
+		opacity: 0.62;
+	}
+
+	.word {
+		display: flex;
+		flex-wrap: nowrap;
+		margin: 0;
+		font-family: var(--lab-kinetic);
+		font-size: clamp(2.4rem, 10.5vw, 7rem);
+		line-height: 0.94;
+		letter-spacing: -0.02em;
+		color: var(--color-heading);
+		user-select: none;
+	}
+
+	// `--k` (0 → 1) is written per glyph by the rAF loop. Everything visual is
+	// derived from it, so the animation is one custom property wide.
+	.letter {
+		--k: 0;
+		display: inline-block;
+		font-variation-settings:
+			'opsz' calc(9 + 135 * var(--k)),
+			'wght' calc(280 + 620 * var(--k)),
+			'SOFT' calc(100 * var(--k)),
+			'WONK' var(--k);
+		transform: translateY(calc(var(--k) * -0.07em)) scaleY(calc(1 + var(--k) * 0.055));
+		color: color-mix(in srgb, var(--lab-accent) calc(var(--k) * 62%), var(--color-heading));
+		will-change: font-variation-settings, transform;
+	}
+
+	.rule {
+		width: 100%;
+		height: 2px;
+		background: var(--lab-hairline);
+		overflow: hidden;
+	}
+
+	.rule-fill {
+		display: block;
+		width: 100%;
+		height: 100%;
+		background: linear-gradient(90deg, transparent, var(--lab-accent), transparent);
+		animation: sweep 4.5s ease-in-out infinite;
+	}
+
+	@keyframes sweep {
+		0%,
+		100% {
+			transform: translateX(-100%);
+		}
+		50% {
+			transform: translateX(100%);
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/Marginalia.svelte
+++ b/personal-website/src/routes/lab/concepts/Marginalia.svelte
@@ -1,0 +1,404 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	type Block = { text: string; note?: string; footnote?: { marker: string; text: string } };
+
+	const blocks: Block[] = [
+		{
+			text: 'A personal site should be cheap to change and expensive to abandon. Mine has been rebuilt five times, and every rebuild has thrown away more than it added.',
+			note: 'Rebuilt in 2019, 2021, 2022, 2024 and again this year.'
+		},
+		{
+			text: 'The first version had a carousel, a testimonial section and a pricing table. I had no clients, no testimonials and nothing to sell. It looked like a business because business websites were the only reference I had.',
+			footnote: {
+				marker: '1',
+				text: 'The pricing table listed three tiers. All three were the same price.'
+			}
+		},
+		{
+			text: 'What survived every rewrite was the boring part: dated notes on books, photographs grouped by trip, and a page that says what I am doing this year. Everything ornamental went in the bin.',
+			note: 'The book notes are the oldest continuously running part of the site.'
+		},
+		{
+			text: 'So the design brief is small. Make the writing legible, make the photographs large, and get out of the way of both.'
+		}
+	];
+
+	let focusMode = $state(true);
+	let host = $state<HTMLDivElement>();
+	let article = $state<HTMLDivElement>();
+	let paragraphs: HTMLParagraphElement[] = [];
+	let noteEls: HTMLElement[] = [];
+	let activeIndex = $state(0);
+	let progress = $state(0);
+	let openFootnote = $state<number | null>(null);
+
+	onMount(() => {
+		if (!host || !article) return;
+
+		let raf = 0;
+
+		function layoutNotes() {
+			// Each margin note is pinned to the top of the paragraph it annotates,
+			// then nudged down if it would collide with the note above it.
+			let floor = 0;
+			for (let i = 0; i < noteEls.length; i++) {
+				const note = noteEls[i];
+				const para = paragraphs[i];
+				if (!note || !para) continue;
+				const top = Math.max(floor, para.offsetTop);
+				note.style.transform = `translateY(${top}px)`;
+				floor = top + note.offsetHeight + 14;
+			}
+		}
+
+		function update() {
+			raf = 0;
+			const rect = host!.getBoundingClientRect();
+			const span = rect.height - window.innerHeight * 0.4;
+			progress = Math.min(
+				1,
+				Math.max(0, (window.innerHeight * 0.5 - rect.top) / Math.max(1, span))
+			);
+
+			// The "active" paragraph is whichever one straddles the reading line at
+			// 42% of the viewport height.
+			const line = window.innerHeight * 0.42;
+			let best = 0;
+			let bestDistance = Infinity;
+			paragraphs.forEach((para, i) => {
+				if (!para) return;
+				const box = para.getBoundingClientRect();
+				const distance = Math.abs(box.top + box.height / 2 - line);
+				if (distance < bestDistance) {
+					bestDistance = distance;
+					best = i;
+				}
+			});
+			activeIndex = best;
+		}
+
+		function onScroll() {
+			if (!raf) raf = requestAnimationFrame(update);
+		}
+
+		layoutNotes();
+		update();
+
+		window.addEventListener('scroll', onScroll, { passive: true });
+		const ro = new ResizeObserver(() => {
+			layoutNotes();
+			update();
+		});
+		ro.observe(article);
+
+		return () => {
+			window.removeEventListener('scroll', onScroll);
+			ro.disconnect();
+			if (raf) cancelAnimationFrame(raf);
+		};
+	});
+
+	const circumference = 2 * Math.PI * 15;
+</script>
+
+<div class="reader" class:focus={focusMode} bind:this={host}>
+	<div class="toolbar">
+		<button
+			class="switch"
+			class:on={focusMode}
+			type="button"
+			onclick={() => (focusMode = !focusMode)}
+		>
+			<span class="knob"></span>
+			<span class="switch-label">Focus mode</span>
+		</button>
+
+		<div class="ring" aria-label={`${Math.round(progress * 100)}% read`}>
+			<svg viewBox="0 0 36 36" aria-hidden="true">
+				<circle cx="18" cy="18" r="15" class="ring-track" />
+				<circle
+					cx="18"
+					cy="18"
+					r="15"
+					class="ring-fill"
+					stroke-dasharray={circumference}
+					stroke-dashoffset={circumference * (1 - progress)}
+				/>
+			</svg>
+			<span class="ring-text lab-mono">{Math.round(progress * 100)}</span>
+		</div>
+	</div>
+
+	<div class="body">
+		<div class="article" bind:this={article}>
+			{#each blocks as block, i (i)}
+				<p class="para" class:active={i === activeIndex} bind:this={paragraphs[i]}>
+					{block.text}
+					{#if block.footnote}
+						<button
+							class="fn"
+							type="button"
+							aria-expanded={openFootnote === i}
+							onclick={() => (openFootnote = openFootnote === i ? null : i)}
+						>
+							{block.footnote.marker}
+						</button>
+						{#if openFootnote === i}
+							<span class="fn-pop" role="note">{block.footnote.text}</span>
+						{/if}
+					{/if}
+				</p>
+			{/each}
+		</div>
+
+		<aside class="margin" aria-label="Margin notes">
+			{#each blocks as block, i (i)}
+				{#if block.note}
+					<span class="note" class:active={i === activeIndex} bind:this={noteEls[i]}>
+						<span class="note-rule" aria-hidden="true"></span>
+						{block.note}
+					</span>
+				{/if}
+			{/each}
+		</aside>
+	</div>
+</div>
+
+<style lang="scss">
+	.reader {
+		display: grid;
+		gap: 1.25rem;
+	}
+
+	.toolbar {
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
+		padding-bottom: 0.85rem;
+		border-bottom: 1px solid var(--lab-hairline);
+	}
+
+	.switch {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.55rem;
+		padding: 0.3rem 0.75rem 0.3rem 0.35rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 999px;
+		background: var(--color-surface);
+	}
+
+	.knob {
+		position: relative;
+		width: 28px;
+		height: 16px;
+		border-radius: 999px;
+		background: var(--color-muted-strong);
+		transition: background 220ms ease;
+	}
+
+	.knob::after {
+		content: '';
+		position: absolute;
+		top: 2px;
+		left: 2px;
+		width: 12px;
+		height: 12px;
+		border-radius: 999px;
+		background: var(--color-surface);
+		transition: transform 260ms cubic-bezier(0.2, 0.9, 0.3, 1.4);
+	}
+
+	.switch.on .knob {
+		background: var(--lab-accent);
+	}
+
+	.switch.on .knob::after {
+		transform: translateX(12px);
+	}
+
+	.switch-label {
+		font-family: var(--font-ui);
+		font-size: 0.8rem;
+		font-weight: 600;
+		color: var(--color-heading);
+	}
+
+	.ring {
+		position: relative;
+		display: grid;
+		place-items: center;
+		width: 40px;
+		height: 40px;
+	}
+
+	.ring svg {
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
+		transform: rotate(-90deg);
+	}
+
+	.ring circle {
+		fill: none;
+		stroke-width: 2.5;
+		stroke-linecap: round;
+	}
+
+	.ring-track {
+		stroke: var(--lab-hairline);
+	}
+
+	.ring-fill {
+		stroke: var(--lab-accent);
+		transition: stroke-dashoffset 120ms linear;
+	}
+
+	.ring-text {
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.body {
+		display: grid;
+		grid-template-columns: minmax(0, 62ch) minmax(0, 20ch);
+		gap: clamp(1.25rem, 4vw, 3rem);
+		align-items: start;
+	}
+
+	.article {
+		display: grid;
+		gap: 1.35rem;
+	}
+
+	.para {
+		position: relative;
+		margin: 0;
+		font-family: var(--font-display);
+		font-size: clamp(1.02rem, 1.4vw, 1.15rem);
+		font-weight: 400;
+		line-height: 1.75;
+		color: var(--color-ink);
+		font-variation-settings:
+			'SOFT' 30,
+			'opsz' 14;
+		transition:
+			opacity 420ms ease,
+			filter 420ms ease;
+	}
+
+	// Focus mode dims everything but the paragraph on the reading line — the
+	// page becomes a soft spotlight that tracks the reader down the column.
+	.reader.focus .para {
+		opacity: 0.34;
+		filter: blur(0.35px);
+	}
+
+	.reader.focus .para.active {
+		opacity: 1;
+		filter: none;
+	}
+
+	.fn {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		width: 1.15em;
+		height: 1.15em;
+		margin-left: 0.12em;
+		vertical-align: super;
+		border: none;
+		border-radius: 999px;
+		background: color-mix(in srgb, var(--lab-accent) 18%, transparent);
+		font-family: var(--lab-mono);
+		font-size: 0.55em;
+		font-weight: 700;
+		color: var(--lab-accent);
+	}
+
+	.fn-pop {
+		display: block;
+		margin-top: 0.6rem;
+		padding: 0.6rem 0.75rem;
+		border-left: 2px solid var(--lab-accent);
+		border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+		background: var(--color-muted);
+		font-family: var(--font-body);
+		font-size: 0.84rem;
+		line-height: 1.55;
+		color: var(--color-subtle);
+		animation: slip 220ms ease;
+	}
+
+	@keyframes slip {
+		from {
+			opacity: 0;
+			transform: translateY(-4px);
+		}
+	}
+
+	.margin {
+		position: relative;
+		min-height: 1px;
+	}
+
+	.note {
+		position: absolute;
+		top: 0;
+		left: 0;
+		display: block;
+		width: 100%;
+		padding-left: 0.85rem;
+		font-family: var(--font-body);
+		font-size: 0.78rem;
+		line-height: 1.5;
+		color: var(--color-subtle);
+		opacity: 0.5;
+		transition:
+			opacity 380ms ease,
+			transform 380ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	.note.active {
+		opacity: 1;
+	}
+
+	.note-rule {
+		position: absolute;
+		left: 0;
+		top: 0.35em;
+		bottom: 0.2em;
+		width: 2px;
+		border-radius: 999px;
+		background: var(--lab-hairline);
+		transition: background 380ms ease;
+	}
+
+	.note.active .note-rule {
+		background: var(--lab-accent);
+	}
+
+	@media (max-width: 820px) {
+		.body {
+			grid-template-columns: minmax(0, 1fr);
+		}
+
+		// Notes fall back to inline asides once there is no margin to live in.
+		.margin {
+			display: grid;
+			gap: 0.75rem;
+		}
+
+		// Stays `relative` rather than `static` so the rule keeps this element as
+		// its containing block instead of jumping to `.margin`.
+		.note {
+			position: relative;
+			transform: none !important;
+			opacity: 1;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/MegaFooter.svelte
+++ b/personal-website/src/routes/lab/concepts/MegaFooter.svelte
@@ -1,0 +1,262 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { photoTrips, siteSettings } from '$lib/content';
+
+	const fill = photoTrips[0]?.coverImage ?? '';
+	const socials = siteSettings.socials.filter((social) => social.href.startsWith('http'));
+
+	let host = $state<HTMLDivElement>();
+	let mark = $state<HTMLDivElement>();
+	let copied = $state(false);
+
+	onMount(() => {
+		if (!host || !mark) return;
+		let raf = 0;
+
+		function update() {
+			raf = 0;
+			const rect = host!.getBoundingClientRect();
+			// 0 as the block enters the viewport, 1 once its top reaches the top.
+			const p = Math.min(1, Math.max(0, 1 - rect.top / window.innerHeight));
+			// The wordmark rises out of the clip as the footer is scrolled into view.
+			mark!.style.setProperty('--rise', p.toFixed(3));
+		}
+
+		function onScroll() {
+			if (!raf) raf = requestAnimationFrame(update);
+		}
+
+		update();
+		window.addEventListener('scroll', onScroll, { passive: true });
+		return () => {
+			window.removeEventListener('scroll', onScroll);
+			if (raf) cancelAnimationFrame(raf);
+		};
+	});
+
+	async function copyEmail() {
+		try {
+			await navigator.clipboard.writeText(siteSettings.email);
+			copied = true;
+			setTimeout(() => (copied = false), 1800);
+		} catch {
+			copied = false;
+		}
+	}
+</script>
+
+<div class="mega lab-grain" bind:this={host}>
+	<div class="top">
+		<div class="say">
+			<span class="lab-mono eyebrow">still reading?</span>
+			<h4>Say hello.</h4>
+			<p>I answer everything that is not a recruiter template.</p>
+		</div>
+
+		<div class="actions">
+			<button class="mail" class:copied type="button" onclick={copyEmail}>
+				<span class="mail-text" data-preserve-case>{siteSettings.email}</span>
+				<span class="mail-icon material-symbols-rounded" aria-hidden="true">
+					{copied ? 'check' : 'content_copy'}
+				</span>
+			</button>
+
+			<ul class="socials">
+				{#each socials as social (social.href)}
+					<li>
+						<a href={social.href} rel="me noreferrer" target="_blank">
+							<span class="social-label" data-preserve-case>{social.label}</span>
+							<span class="material-symbols-rounded" aria-hidden="true">north_east</span>
+						</a>
+					</li>
+				{/each}
+			</ul>
+		</div>
+	</div>
+
+	<div class="wordmark" bind:this={mark} aria-hidden="true">
+		<span class="fill" style={`background-image:url(${fill})`}>MATEJ</span>
+		<span class="outline">MATEJ</span>
+	</div>
+
+	<div class="baseline lab-mono">
+		<span>© {new Date().getFullYear()}</span>
+		<span>built in melbourne</span>
+		<span>sveltekit · no trackers worth mentioning</span>
+	</div>
+</div>
+
+<style lang="scss">
+	.mega {
+		position: relative;
+		// The wordmark is sized in `cqw`, so the footer itself is the container it
+		// measures against — sizing off `vw` overflowed whenever the page column
+		// was narrower than the viewport.
+		container-type: inline-size;
+		display: grid;
+		gap: clamp(1.5rem, 4vw, 2.5rem);
+		padding: clamp(2rem, 5vw, 3.5rem) clamp(1.25rem, 4vw, 2.5rem) 0;
+		border-radius: var(--radius-lg);
+		background: var(--color-ink);
+		color: var(--color-cream);
+		overflow: hidden;
+	}
+
+	.top {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-end;
+		justify-content: space-between;
+		gap: 1.5rem;
+	}
+
+	.eyebrow {
+		font-size: 0.55rem;
+		color: color-mix(in srgb, var(--color-cream) 55%, transparent);
+	}
+
+	.say h4 {
+		margin: 0.35rem 0 0.3rem;
+		font-family: var(--font-display);
+		font-size: clamp(1.7rem, 4vw, 2.6rem);
+		font-weight: 500;
+		letter-spacing: -0.03em;
+		color: var(--color-cream);
+		font-variation-settings: 'SOFT' 50;
+	}
+
+	.say p {
+		margin: 0;
+		font-size: 0.95rem;
+		color: color-mix(in srgb, var(--color-cream) 65%, transparent);
+	}
+
+	.actions {
+		display: grid;
+		gap: 0.85rem;
+		justify-items: start;
+	}
+
+	.mail {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.6rem;
+		padding: 0.6rem 0.9rem;
+		border: 1px solid color-mix(in srgb, var(--color-cream) 22%, transparent);
+		border-radius: 999px;
+		background: transparent;
+		color: var(--color-cream);
+		font-family: var(--lab-mono);
+		font-size: 0.78rem;
+		transition:
+			border-color 220ms ease,
+			background 220ms ease;
+	}
+
+	.mail:hover {
+		border-color: var(--color-green);
+		background: color-mix(in srgb, var(--color-green) 16%, transparent);
+	}
+
+	.mail.copied {
+		border-color: var(--color-green);
+		color: var(--color-green);
+	}
+
+	.mail-icon {
+		font-size: 1rem;
+		transition: transform 260ms cubic-bezier(0.2, 0.9, 0.3, 1.5);
+	}
+
+	.mail.copied .mail-icon {
+		transform: scale(1.25);
+	}
+
+	.socials {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem 1.1rem;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.socials a {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		font-family: var(--font-ui);
+		font-size: 0.82rem;
+		font-weight: 500;
+		color: color-mix(in srgb, var(--color-cream) 72%, transparent);
+		text-decoration: none;
+	}
+
+	.socials a:hover {
+		color: var(--color-cream);
+	}
+
+	.socials .material-symbols-rounded {
+		font-size: 0.85rem;
+		transition: transform 220ms cubic-bezier(0.2, 0.9, 0.3, 1.5);
+	}
+
+	.socials a:hover .material-symbols-rounded {
+		transform: translate(2px, -2px);
+	}
+
+	// The wordmark is clipped by the footer's bottom edge and slides up into
+	// view as the block is scrolled — the name arrives, it does not just sit there.
+	.wordmark {
+		--rise: 0;
+		position: relative;
+		margin: 0 -0.04em;
+		line-height: 0.76;
+		overflow: hidden;
+		height: 0.62em;
+		font-family: var(--font-ui);
+		font-size: clamp(3rem, 25cqw, 15rem);
+		font-weight: 900;
+		letter-spacing: -0.045em;
+		text-align: center;
+	}
+
+	.wordmark span {
+		display: block;
+		transform: translateY(calc((1 - var(--rise)) * 0.35em));
+	}
+
+	.fill {
+		background-size: cover;
+		background-position: center 40%;
+		-webkit-background-clip: text;
+		background-clip: text;
+		color: transparent;
+	}
+
+	// A faint outline sits behind the photo fill so the letterforms survive
+	// against dark parts of the image.
+	.outline {
+		position: absolute;
+		inset: 0;
+		z-index: -1;
+		color: transparent;
+		-webkit-text-stroke: 1px color-mix(in srgb, var(--color-cream) 18%, transparent);
+	}
+
+	.baseline {
+		display: flex;
+		flex-wrap: wrap;
+		justify-content: space-between;
+		gap: 0.5rem 1.5rem;
+		padding: 0 0 1rem;
+		font-size: 0.55rem;
+		color: color-mix(in srgb, var(--color-cream) 45%, transparent);
+	}
+
+	@media (max-width: 640px) {
+		.baseline {
+			justify-content: flex-start;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/PhotoDeck.svelte
+++ b/personal-website/src/routes/lab/concepts/PhotoDeck.svelte
@@ -1,0 +1,258 @@
+<script lang="ts">
+	import { photoTrips } from '$lib/content';
+
+	type Slide = { src: string; alt: string; location: string; when: string; trip: string };
+
+	// One featured frame per trip, so the deck reads as a highlight reel.
+	const slides: Slide[] = photoTrips.slice(0, 8).map((trip) => {
+		const shot = trip.images.find((image) => image.featured) ?? trip.images[0];
+		return {
+			src: shot.src,
+			alt: shot.alt,
+			location: shot.location,
+			when: shot.capturedAtLabel,
+			trip: trip.title
+		};
+	});
+
+	let order = $state(slides.map((_, i) => i));
+	let drag = $state({ x: 0, y: 0, active: false });
+	let flying = $state<'left' | 'right' | null>(null);
+
+	const top = $derived(order[0]);
+
+	function advance(direction: 'left' | 'right') {
+		flying = direction;
+		// Let the throw animation play before the card is cycled to the back.
+		setTimeout(() => {
+			order = [...order.slice(1), order[0]];
+			drag = { x: 0, y: 0, active: false };
+			flying = null;
+		}, 260);
+	}
+
+	function onPointerDown(event: PointerEvent) {
+		if (flying) return;
+		(event.currentTarget as HTMLElement).setPointerCapture(event.pointerId);
+		drag = { x: 0, y: 0, active: true };
+	}
+
+	function onPointerMove(event: PointerEvent) {
+		if (!drag.active) return;
+		drag = { x: drag.x + event.movementX, y: drag.y + event.movementY, active: true };
+	}
+
+	function onPointerUp() {
+		if (!drag.active) return;
+		// 110px of travel is the commit threshold; anything less springs back.
+		if (Math.abs(drag.x) > 110) advance(drag.x > 0 ? 'right' : 'left');
+		else drag = { x: 0, y: 0, active: false };
+	}
+
+	function transform(index: number) {
+		if (index === 0) {
+			if (flying) {
+				const dir = flying === 'right' ? 1 : -1;
+				return `translate3d(${dir * 140}%, ${drag.y}px, 0) rotate(${dir * 22}deg)`;
+			}
+			return `translate3d(${drag.x}px, ${drag.y}px, 0) rotate(${drag.x * 0.045}deg)`;
+		}
+		const depth = Math.min(index, 4);
+		return `translate3d(0, ${depth * 12}px, 0) scale(${1 - depth * 0.045})`;
+	}
+</script>
+
+<div class="deck-wrap">
+	<div class="deck">
+		{#each order as slideIndex, position (slideIndex)}
+			{@const slide = slides[slideIndex]}
+			<!-- svelte-ignore a11y_no_static_element_interactions -->
+			<div
+				class="card"
+				class:top={position === 0}
+				class:settling={position === 0 && !drag.active}
+				style={`z-index:${slides.length - position}; transform:${transform(position)}; opacity:${
+					position > 4 ? 0 : 1
+				}`}
+				onpointerdown={position === 0 ? onPointerDown : undefined}
+				onpointermove={position === 0 ? onPointerMove : undefined}
+				onpointerup={position === 0 ? onPointerUp : undefined}
+				onpointercancel={position === 0 ? onPointerUp : undefined}
+			>
+				<img
+					src={slide.src}
+					alt={position === 0 ? slide.alt : ''}
+					loading="lazy"
+					draggable="false"
+				/>
+				<div class="plate">
+					<span class="trip" data-preserve-case>{slide.trip}</span>
+					<span class="where">{slide.location}</span>
+					<span class="when lab-mono">{slide.when}</span>
+				</div>
+				{#if position === 0}
+					<span class="stamp keep" style={`opacity:${Math.max(0, drag.x / 110)}`}>keep</span>
+					<span class="stamp skip" style={`opacity:${Math.max(0, -drag.x / 110)}`}>next</span>
+				{/if}
+			</div>
+		{/each}
+	</div>
+
+	<div class="controls">
+		<button type="button" aria-label="Previous photo" onclick={() => advance('left')}>
+			<span class="material-symbols-rounded" aria-hidden="true">arrow_back</span>
+		</button>
+		<span class="counter lab-mono">
+			{String(top + 1).padStart(2, '0')} / {String(slides.length).padStart(2, '0')}
+		</span>
+		<button type="button" aria-label="Next photo" onclick={() => advance('right')}>
+			<span class="material-symbols-rounded" aria-hidden="true">arrow_forward</span>
+		</button>
+	</div>
+</div>
+
+<style lang="scss">
+	.deck-wrap {
+		display: grid;
+		justify-items: center;
+		gap: 1.1rem;
+	}
+
+	.deck {
+		position: relative;
+		width: min(340px, 100%);
+		aspect-ratio: 4 / 5;
+		perspective: 1000px;
+	}
+
+	.card {
+		position: absolute;
+		inset: 0;
+		border-radius: var(--radius-lg);
+		background: var(--color-surface);
+		border: 1px solid var(--lab-hairline);
+		box-shadow: 0 18px 44px -22px rgb(0 0 0 / 0.55);
+		overflow: hidden;
+		will-change: transform;
+		user-select: none;
+		touch-action: none;
+	}
+
+	// Only the settled state animates: while a finger is down the card must
+	// track the pointer exactly, with no transition lag.
+	.card.settling,
+	.card:not(.top) {
+		transition:
+			transform 380ms cubic-bezier(0.2, 0.9, 0.3, 1.05),
+			opacity 300ms ease;
+	}
+
+	.card.top {
+		cursor: grab;
+	}
+
+	.card.top:active {
+		cursor: grabbing;
+	}
+
+	.card img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		pointer-events: none;
+	}
+
+	.plate {
+		position: absolute;
+		left: 0;
+		right: 0;
+		bottom: 0;
+		display: grid;
+		grid-template-columns: 1fr auto;
+		gap: 0.1rem 0.6rem;
+		padding: 2.5rem 0.95rem 0.9rem;
+		background: linear-gradient(to top, rgb(8 10 9 / 0.82), transparent);
+		color: #f4f2ec;
+	}
+
+	.trip {
+		grid-column: 1;
+		font-family: var(--font-ui);
+		font-size: 1rem;
+		font-weight: 650;
+		letter-spacing: -0.02em;
+	}
+
+	.where {
+		grid-column: 1;
+		grid-row: 2;
+		font-size: 0.78rem;
+		opacity: 0.72;
+	}
+
+	.when {
+		grid-column: 2;
+		grid-row: 1 / span 2;
+		align-self: center;
+		font-size: 0.55rem;
+		opacity: 0.6;
+	}
+
+	// Polaroid-style verdict stamps that fade in as the card is dragged.
+	.stamp {
+		position: absolute;
+		top: 1.1rem;
+		padding: 0.25rem 0.7rem;
+		border: 2.5px solid currentColor;
+		border-radius: var(--radius-sm);
+		font-family: var(--lab-mono);
+		font-size: 0.72rem;
+		font-weight: 700;
+		letter-spacing: 0.18em;
+		text-transform: uppercase;
+		pointer-events: none;
+	}
+
+	.keep {
+		left: 1.1rem;
+		color: #35d07f;
+		transform: rotate(-14deg);
+	}
+
+	.skip {
+		right: 1.1rem;
+		color: #ff6b6b;
+		transform: rotate(14deg);
+	}
+
+	.controls {
+		display: flex;
+		align-items: center;
+		gap: 0.9rem;
+	}
+
+	button {
+		display: grid;
+		place-items: center;
+		width: 2.4rem;
+		height: 2.4rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 999px;
+		background: var(--color-surface);
+		color: var(--color-heading);
+		transition:
+			border-color var(--duration-fast) ease,
+			transform var(--duration-fast) ease;
+	}
+
+	button:hover {
+		border-color: var(--lab-accent);
+		transform: translateY(-2px);
+	}
+
+	.counter {
+		font-size: 0.6rem;
+		color: var(--color-subtle);
+		font-variant-numeric: tabular-nums;
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/PhysicsTags.svelte
+++ b/personal-website/src/routes/lab/concepts/PhysicsTags.svelte
@@ -1,0 +1,282 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	type Props = { tags?: string[] };
+	let {
+		tags = [
+			'SvelteKit',
+			'TypeScript',
+			'photography',
+			'Sony α6700',
+			'trail running',
+			'Atlassian',
+			'SCSS',
+			'book notes',
+			'film',
+			'Melbourne',
+			'design systems',
+			'espresso',
+			'Figma',
+			'long walks'
+		]
+	}: Props = $props();
+
+	let host = $state<HTMLDivElement>();
+	let ready = $state(false);
+	let flipped = $state(false);
+
+	let api: {
+		shake: () => void;
+		flip: () => void;
+		reset: () => void;
+	} | null = null;
+
+	onMount(() => {
+		let disposed = false;
+		let cleanup: (() => void) | undefined;
+
+		// matter-js touches `window` at import time, so it can only be pulled in
+		// on the client — hence the dynamic import rather than a static one.
+		void (async () => {
+			const Matter = await import('matter-js');
+			if (disposed || !host) return;
+
+			const { Engine, Runner, World, Bodies, Body, Composite, Mouse, MouseConstraint, Events } =
+				Matter;
+
+			const engine = Engine.create({ gravity: { x: 0, y: 1, scale: 0.0011 } });
+			const world = engine.world;
+
+			const chips = Array.from(host.querySelectorAll<HTMLElement>('.chip'));
+			const rect = host.getBoundingClientRect();
+			const W = rect.width;
+			const H = rect.height;
+			const WALL = 200;
+			// Tags are dropped in from above, so the ceiling has to sit above the
+			// whole spawn band — otherwise they land on top of it and never arrive.
+			const CEILING = -420;
+
+			const walls = [
+				Bodies.rectangle(W / 2, H + WALL / 2, W * 3, WALL, { isStatic: true }),
+				Bodies.rectangle(W / 2, CEILING - WALL / 2, W * 3, WALL, { isStatic: true }),
+				Bodies.rectangle(-WALL / 2, H / 2, WALL, (H - CEILING) * 2, { isStatic: true }),
+				Bodies.rectangle(W + WALL / 2, H / 2, WALL, (H - CEILING) * 2, { isStatic: true })
+			];
+			World.add(world, walls);
+
+			/** A spawn point in the band between the ceiling and the top of the pit. */
+			const dropAt = () => ({
+				x: 40 + Math.random() * Math.max(1, W - 80),
+				y: -40 - Math.random() * 320
+			});
+
+			const bodies = chips.map((chip) => {
+				const size = chip.getBoundingClientRect();
+				const spawn = dropAt();
+				const body = Bodies.rectangle(spawn.x, spawn.y, size.width, size.height, {
+					chamfer: { radius: Math.min(size.width, size.height) / 2 - 1 },
+					restitution: 0.55,
+					friction: 0.28,
+					frictionAir: 0.012,
+					density: 0.0016
+				});
+				Body.setAngle(body, (Math.random() - 0.5) * 0.6);
+				return { chip, body, size };
+			});
+			World.add(
+				world,
+				bodies.map((entry) => entry.body)
+			);
+
+			const mouse = Mouse.create(host);
+			const mouseConstraint = MouseConstraint.create(engine, {
+				mouse,
+				constraint: { stiffness: 0.18, render: { visible: false } }
+			});
+			World.add(world, mouseConstraint);
+
+			// Matter binds a wheel handler to steal zoom gestures; drop it so the
+			// page keeps scrolling normally when the cursor is over the pit.
+			const wheelHandler = (mouse as unknown as { mousewheel: (event: Event) => void }).mousewheel;
+			mouse.element.removeEventListener('wheel', wheelHandler);
+			mouse.element.removeEventListener('DOMMouseScroll', wheelHandler);
+
+			const sync = () => {
+				for (const { chip, body, size } of bodies) {
+					chip.style.transform = `translate3d(${body.position.x - size.width / 2}px, ${
+						body.position.y - size.height / 2
+					}px, 0) rotate(${body.angle}rad)`;
+				}
+			};
+			Events.on(engine, 'afterUpdate', sync);
+
+			const runner = Runner.create();
+			Runner.run(runner, engine);
+			ready = true;
+
+			api = {
+				shake() {
+					for (const { body } of bodies) {
+						Body.setVelocity(body, {
+							x: (Math.random() - 0.5) * 22,
+							y: -6 - Math.random() * 12
+						});
+						Body.setAngularVelocity(body, (Math.random() - 0.5) * 0.5);
+					}
+				},
+				flip() {
+					flipped = !flipped;
+					engine.gravity.y = flipped ? -1 : 1;
+					api?.shake();
+				},
+				reset() {
+					for (const { body } of bodies) {
+						Body.setPosition(body, dropAt());
+						Body.setVelocity(body, { x: 0, y: 0 });
+						Body.setAngularVelocity(body, 0);
+					}
+					flipped = false;
+					engine.gravity.y = 1;
+				}
+			};
+
+			// Pause the solver when the pit is off-screen — it is a physics loop,
+			// not decoration, and there is no reason to burn cycles unseen.
+			const io = new IntersectionObserver(
+				([entry]) => {
+					runner.enabled = entry.isIntersecting;
+				},
+				{ threshold: 0 }
+			);
+			io.observe(host);
+
+			cleanup = () => {
+				io.disconnect();
+				Runner.stop(runner);
+				Events.off(engine, 'afterUpdate', sync);
+				Composite.clear(world, false);
+				Engine.clear(engine);
+			};
+		})();
+
+		return () => {
+			disposed = true;
+			cleanup?.();
+		};
+	});
+</script>
+
+<div class="pit-wrap">
+	<div class="pit lab-grid-bg" class:ready bind:this={host}>
+		{#each tags as tag (tag)}
+			<span class="chip" data-preserve-case>{tag}</span>
+		{/each}
+		{#if !ready}
+			<span class="loading lab-mono">warming up the solver…</span>
+		{/if}
+	</div>
+
+	<div class="tools">
+		<button type="button" onclick={() => api?.shake()}>Shake</button>
+		<button type="button" onclick={() => api?.flip()}>
+			{flipped ? 'Gravity: up' : 'Gravity: down'}
+		</button>
+		<button type="button" onclick={() => api?.reset()}>Drop again</button>
+		<span class="lab-mono note">grab and throw them</span>
+	</div>
+</div>
+
+<style lang="scss">
+	.pit-wrap {
+		display: grid;
+		gap: 0.75rem;
+	}
+
+	.pit {
+		position: relative;
+		height: clamp(280px, 38vw, 380px);
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-md);
+		background-color: var(--color-surface);
+		overflow: hidden;
+		cursor: grab;
+		touch-action: none;
+		opacity: 0;
+		transition: opacity 400ms ease;
+	}
+
+	.pit.ready {
+		opacity: 1;
+	}
+
+	.pit:active {
+		cursor: grabbing;
+	}
+
+	.chip {
+		position: absolute;
+		top: 0;
+		left: 0;
+		display: inline-flex;
+		align-items: center;
+		padding: 0.42rem 0.85rem;
+		border-radius: 999px;
+		border: 1px solid color-mix(in srgb, var(--lab-accent) 35%, transparent);
+		background: color-mix(in srgb, var(--lab-accent) 12%, var(--color-surface));
+		font-family: var(--font-ui);
+		font-size: 0.82rem;
+		font-weight: 600;
+		white-space: nowrap;
+		color: var(--color-heading);
+		box-shadow: var(--shadow-subtle);
+		user-select: none;
+		will-change: transform;
+	}
+
+	// Every third chip inverts, so the pile has some rhythm rather than reading
+	// as one flat wall of outlines.
+	.chip:nth-child(3n) {
+		background: var(--lab-accent);
+		border-color: var(--lab-accent);
+		color: #fff;
+	}
+
+	.loading {
+		position: absolute;
+		inset: 0;
+		display: grid;
+		place-items: center;
+		font-size: 0.58rem;
+		color: var(--color-subtle);
+	}
+
+	.tools {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 0.4rem;
+	}
+
+	button {
+		padding: 0.45rem 0.85rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 999px;
+		background: var(--color-surface);
+		font-family: var(--font-ui);
+		font-size: 0.78rem;
+		font-weight: 600;
+		color: var(--color-heading);
+		transition: border-color var(--duration-fast) ease;
+	}
+
+	button:hover {
+		border-color: var(--lab-accent);
+	}
+
+	.note {
+		margin-left: 0.3rem;
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+		opacity: 0.7;
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/ReactionBar.svelte
+++ b/personal-website/src/routes/lab/concepts/ReactionBar.svelte
@@ -1,0 +1,196 @@
+<script lang="ts">
+	type Reaction = { emoji: string; label: string; count: number; mine: boolean };
+
+	let reactions = $state<Reaction[]>([
+		{ emoji: '👏', label: 'applause', count: 34, mine: false },
+		{ emoji: '🤔', label: 'thinking', count: 12, mine: false },
+		{ emoji: '📷', label: 'nice frame', count: 27, mine: false },
+		{ emoji: '🔥', label: 'fire', count: 8, mine: false }
+	]);
+
+	type Particle = { id: number; emoji: string; dx: number; dy: number; rot: number; scale: number };
+	let particles = $state<Particle[]>([]);
+	let seq = 0;
+
+	function burst(reaction: Reaction, count: number) {
+		const spawned: Particle[] = Array.from({ length: count }, () => ({
+			id: seq++,
+			emoji: reaction.emoji,
+			// Cone upward: a spread of ±55° off vertical, with varied throw length.
+			dx: (Math.random() - 0.5) * 130,
+			dy: -70 - Math.random() * 90,
+			rot: (Math.random() - 0.5) * 120,
+			scale: 0.7 + Math.random() * 0.8
+		}));
+		particles = [...particles, ...spawned];
+
+		const ids = new Set(spawned.map((p) => p.id));
+		setTimeout(() => {
+			particles = particles.filter((p) => !ids.has(p.id));
+		}, 1100);
+	}
+
+	function toggle(index: number) {
+		const reaction = reactions[index];
+		const mine = !reaction.mine;
+		reactions = reactions.map((item, i) =>
+			i === index ? { ...item, mine, count: item.count + (mine ? 1 : -1) } : item
+		);
+		if (mine) burst(reaction, 12);
+	}
+
+	/** Holding a button keeps throwing confetti without inflating the count. */
+	let holdTimer: ReturnType<typeof setInterval> | null = null;
+
+	function startHold(index: number) {
+		stopHold();
+		holdTimer = setInterval(() => burst(reactions[index], 4), 130);
+	}
+
+	function stopHold() {
+		if (holdTimer) clearInterval(holdTimer);
+		holdTimer = null;
+	}
+
+	const total = $derived(reactions.reduce((sum, item) => sum + item.count, 0));
+</script>
+
+<svelte:window onpointerup={stopHold} />
+
+<div class="reactions">
+	<div class="bar">
+		{#each reactions as reaction, i (reaction.label)}
+			<button
+				class="react"
+				class:mine={reaction.mine}
+				type="button"
+				aria-pressed={reaction.mine}
+				aria-label={`${reaction.label}, ${reaction.count} reactions`}
+				onclick={() => toggle(i)}
+				onpointerdown={() => startHold(i)}
+				onpointerleave={stopHold}
+			>
+				<span class="emoji" data-preserve-case>{reaction.emoji}</span>
+				<span class="count lab-mono">{reaction.count}</span>
+
+				<span class="stage" aria-hidden="true">
+					{#each particles.filter((p) => p.emoji === reaction.emoji) as particle (particle.id)}
+						<span
+							class="particle"
+							style={`--dx:${particle.dx}px; --dy:${particle.dy}px; --rot:${particle.rot}deg; --s:${particle.scale}`}
+						>
+							{particle.emoji}
+						</span>
+					{/each}
+				</span>
+			</button>
+		{/each}
+	</div>
+
+	<p class="meta lab-mono">
+		{total} reactions · tap to react, hold for confetti
+	</p>
+</div>
+
+<style lang="scss">
+	.reactions {
+		display: grid;
+		gap: 0.7rem;
+		justify-items: start;
+	}
+
+	.bar {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.45rem;
+	}
+
+	.react {
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		padding: 0.45rem 0.8rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 999px;
+		background: var(--color-surface);
+		transition:
+			transform 180ms cubic-bezier(0.2, 0.9, 0.3, 1.4),
+			border-color 180ms ease,
+			background 180ms ease;
+	}
+
+	.react:hover {
+		transform: translateY(-2px);
+	}
+
+	.react:active {
+		transform: translateY(0) scale(0.96);
+	}
+
+	.react.mine {
+		border-color: var(--lab-accent);
+		background: color-mix(in srgb, var(--lab-accent) 12%, var(--color-surface));
+	}
+
+	.emoji {
+		font-size: 1.05rem;
+		line-height: 1;
+		transition: transform 200ms cubic-bezier(0.2, 0.9, 0.3, 1.5);
+	}
+
+	.react.mine .emoji {
+		transform: scale(1.18) rotate(-8deg);
+	}
+
+	.count {
+		font-size: 0.62rem;
+		color: var(--color-subtle);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.react.mine .count {
+		color: var(--lab-accent);
+	}
+
+	// Particles are emitted from the button's centre and are allowed to escape
+	// its bounds, so the stage is a zero-size anchor rather than an overlay.
+	.stage {
+		position: absolute;
+		left: 50%;
+		top: 50%;
+		width: 0;
+		height: 0;
+		pointer-events: none;
+	}
+
+	.particle {
+		position: absolute;
+		left: 0;
+		top: 0;
+		font-size: 1rem;
+		line-height: 1;
+		animation: fly 1s cubic-bezier(0.15, 0.7, 0.3, 1) forwards;
+	}
+
+	@keyframes fly {
+		0% {
+			opacity: 0;
+			transform: translate(-50%, -50%) scale(0.2);
+		}
+		12% {
+			opacity: 1;
+		}
+		100% {
+			opacity: 0;
+			transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) rotate(var(--rot))
+				scale(var(--s));
+		}
+	}
+
+	.meta {
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+		opacity: 0.75;
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/ScrollTimeline.svelte
+++ b/personal-website/src/routes/lab/concepts/ScrollTimeline.svelte
@@ -1,0 +1,259 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { reveal } from '$lib/actions/reveal';
+	import { year2026Timeline } from '$lib/content';
+
+	const entries = [...year2026Timeline].sort((a, b) => b.date.localeCompare(a.date));
+
+	/**
+	 * Scroll-driven CSS animations do the work where they exist (no observers, no
+	 * rAF, runs off the main thread). Everywhere else the existing `reveal`
+	 * action is the fallback, so the two paths never fight over opacity.
+	 */
+	let native = $state(false);
+	onMount(() => {
+		native =
+			typeof CSS !== 'undefined' &&
+			CSS.supports?.('animation-timeline', 'view()') &&
+			!window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+	});
+
+	function label(date: string) {
+		const parsed = new Date(`${date}T00:00:00Z`);
+		return {
+			day: String(parsed.getUTCDate()).padStart(2, '0'),
+			month: parsed.toLocaleDateString('en-AU', { month: 'short', timeZone: 'UTC' })
+		};
+	}
+</script>
+
+<div class="log" class:native>
+	<div class="rail" aria-hidden="true">
+		<span class="rail-track"></span>
+		<span class="rail-fill"></span>
+	</div>
+
+	<ol>
+		{#each entries as entry, i (entry.date + entry.title)}
+			{@const stamp = label(entry.date)}
+			<li class="entry" style={`--i:${i}`}>
+				{#if !native}
+					<div class="revealer" use:reveal={{ delay: i * 60, distance: 24 }}>
+						<span class="node" aria-hidden="true"></span>
+						<time class="stamp" datetime={entry.date}>
+							<span class="day">{stamp.day}</span>
+							<span class="month lab-mono">{stamp.month}</span>
+						</time>
+						<div class="body">
+							<h4 data-preserve-case>{entry.title}</h4>
+							<span class="year lab-mono">{entry.date.slice(0, 4)}</span>
+						</div>
+					</div>
+				{:else}
+					<span class="node" aria-hidden="true"></span>
+					<time class="stamp" datetime={entry.date}>
+						<span class="day">{stamp.day}</span>
+						<span class="month lab-mono">{stamp.month}</span>
+					</time>
+					<div class="body">
+						<h4 data-preserve-case>{entry.title}</h4>
+						<span class="year lab-mono">{entry.date.slice(0, 4)}</span>
+					</div>
+				{/if}
+			</li>
+		{/each}
+	</ol>
+
+	<p class="foot lab-mono">
+		{native ? 'running on native scroll-driven animations' : 'observer fallback in use'}
+	</p>
+</div>
+
+<style lang="scss">
+	.log {
+		position: relative;
+		padding-left: clamp(2.25rem, 5vw, 3.25rem);
+	}
+
+	.rail {
+		position: absolute;
+		left: clamp(0.9rem, 2vw, 1.4rem);
+		top: 0.4rem;
+		bottom: 2.4rem;
+		width: 2px;
+	}
+
+	.rail-track,
+	.rail-fill {
+		position: absolute;
+		inset: 0;
+		border-radius: 999px;
+	}
+
+	.rail-track {
+		background: var(--lab-hairline);
+	}
+
+	.rail-fill {
+		background: linear-gradient(
+			to bottom,
+			var(--lab-accent),
+			color-mix(in srgb, var(--lab-accent) 35%, transparent)
+		);
+		transform-origin: top center;
+		transform: scaleY(1);
+	}
+
+	ol {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: grid;
+		gap: clamp(1.1rem, 2.5vw, 1.6rem);
+	}
+
+	.entry,
+	.revealer {
+		position: relative;
+		display: grid;
+		grid-template-columns: auto minmax(0, 1fr);
+		align-items: center;
+		gap: 0.9rem;
+	}
+
+	.revealer {
+		grid-column: 1 / -1;
+	}
+
+	.node {
+		position: absolute;
+		left: calc(clamp(2.25rem, 5vw, 3.25rem) * -1 + clamp(0.9rem, 2vw, 1.4rem) - 4px);
+		width: 10px;
+		height: 10px;
+		border-radius: 999px;
+		border: 2px solid var(--color-cream);
+		background: var(--lab-accent);
+		box-shadow: 0 0 0 3px color-mix(in srgb, var(--lab-accent) 22%, transparent);
+	}
+
+	.stamp {
+		display: grid;
+		justify-items: center;
+		width: 3rem;
+		padding: 0.35rem 0;
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-md);
+		background: var(--color-surface);
+	}
+
+	.day {
+		font-family: var(--font-ui);
+		font-size: 1.05rem;
+		font-weight: 700;
+		line-height: 1;
+		color: var(--color-heading);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.month {
+		font-size: 0.54rem;
+		color: var(--color-subtle);
+	}
+
+	.body {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 0.75rem;
+		min-width: 0;
+		padding-bottom: 0.65rem;
+		border-bottom: 1px dashed var(--lab-hairline);
+	}
+
+	h4 {
+		margin: 0;
+		font-family: var(--font-ui);
+		font-size: clamp(0.95rem, 1.5vw, 1.08rem);
+		font-weight: 550;
+		letter-spacing: -0.015em;
+		color: var(--color-heading);
+	}
+
+	.year {
+		flex: 0 0 auto;
+		font-size: 0.56rem;
+		color: var(--color-subtle);
+		opacity: 0.7;
+	}
+
+	.foot {
+		margin: 1.5rem 0 0;
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+		opacity: 0.6;
+	}
+
+	// --- native scroll-driven path -------------------------------------------
+	// Progress is a function of scroll position, not of time, so the rail is
+	// scrubbable both ways and costs nothing on the main thread.
+	@supports (animation-timeline: view()) {
+		.log.native .rail-fill {
+			animation: draw linear both;
+			animation-timeline: view();
+			animation-range: entry 30% exit 45%;
+		}
+
+		.log.native .entry {
+			animation: rise linear both;
+			animation-timeline: view();
+			animation-range: entry 5% cover 32%;
+		}
+
+		.log.native .node {
+			animation: pop linear both;
+			animation-timeline: view();
+			animation-range: entry 12% cover 30%;
+		}
+	}
+
+	@keyframes draw {
+		from {
+			transform: scaleY(0);
+		}
+		to {
+			transform: scaleY(1);
+		}
+	}
+
+	@keyframes rise {
+		from {
+			opacity: 0;
+			transform: translate3d(0, 26px, 0);
+			filter: blur(3px);
+		}
+		to {
+			opacity: 1;
+			transform: none;
+			filter: blur(0);
+		}
+	}
+
+	@keyframes pop {
+		from {
+			transform: scale(0.2);
+			box-shadow: 0 0 0 0 color-mix(in srgb, var(--lab-accent) 22%, transparent);
+		}
+		to {
+			transform: scale(1);
+			box-shadow: 0 0 0 3px color-mix(in srgb, var(--lab-accent) 22%, transparent);
+		}
+	}
+
+	@media (max-width: 520px) {
+		.body {
+			flex-direction: column;
+			align-items: flex-start;
+			gap: 0.15rem;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/SpotlightGrid.svelte
+++ b/personal-website/src/routes/lab/concepts/SpotlightGrid.svelte
@@ -1,0 +1,253 @@
+<script lang="ts">
+	type Card = { icon: string; title: string; body: string; meta: string; href: string };
+
+	const cards: Card[] = [
+		{
+			icon: 'photo_camera',
+			title: 'Photography',
+			body: 'Trips, rolls and the occasional accident worth keeping.',
+			meta: '14 trips',
+			href: '/photography'
+		},
+		{
+			icon: 'menu_book',
+			title: 'Book notes',
+			body: 'Summaries in three sentences, then everything that stuck.',
+			meta: '33 notes',
+			href: '/booknotes'
+		},
+		{
+			icon: 'edit_note',
+			title: 'Writing',
+			body: 'Short essays on tools, habits and building things slowly.',
+			meta: 'occasional',
+			href: '/writing'
+		},
+		{
+			icon: 'calendar_today',
+			title: '2026',
+			body: 'A living log of what I am actually working on this year.',
+			meta: 'updated weekly',
+			href: '/2026'
+		},
+		{
+			icon: 'terminal',
+			title: 'Uses',
+			body: 'The camera, the editor, the keyboard, the coffee.',
+			meta: 'gear list',
+			href: '/uses'
+		},
+		{
+			icon: 'mail',
+			title: 'Contact',
+			body: 'For work, film recommendations or a coffee in Melbourne.',
+			meta: 'replies fast',
+			href: '/contact'
+		}
+	];
+
+	let grid = $state<HTMLDivElement>();
+
+	/**
+	 * One pointer handler for the whole grid rather than one per card: the shared
+	 * torch position is written to the grid element, and each card resolves its
+	 * own local coordinates from it in CSS. Card rects are read once per move via
+	 * a cached list so a six-card grid costs one layout read, not six.
+	 */
+	let rects: { el: HTMLElement; rect: DOMRect }[] = [];
+
+	function measure() {
+		if (!grid) return;
+		rects = Array.from(grid.querySelectorAll<HTMLElement>('.card')).map((el) => ({
+			el,
+			rect: el.getBoundingClientRect()
+		}));
+	}
+
+	function onMove(event: PointerEvent) {
+		if (!grid) return;
+		if (!rects.length) measure();
+
+		const gridRect = grid.getBoundingClientRect();
+		grid.style.setProperty('--gx', `${event.clientX - gridRect.left}px`);
+		grid.style.setProperty('--gy', `${event.clientY - gridRect.top}px`);
+
+		for (const { el, rect } of rects) {
+			const x = event.clientX - rect.left;
+			const y = event.clientY - rect.top;
+			el.style.setProperty('--x', `${x}px`);
+			el.style.setProperty('--y', `${y}px`);
+
+			// Proximity drives the border glow: 1 at the card's centre, 0 once the
+			// pointer is more than a card-and-a-half away.
+			const dx = Math.max(rect.left - event.clientX, 0, event.clientX - rect.right);
+			const dy = Math.max(rect.top - event.clientY, 0, event.clientY - rect.bottom);
+			const near = Math.max(0, 1 - Math.hypot(dx, dy) / 190);
+			el.style.setProperty('--near', near.toFixed(3));
+		}
+	}
+
+	function onLeave() {
+		for (const { el } of rects) el.style.setProperty('--near', '0');
+		grid?.style.setProperty('--torch', '0');
+	}
+
+	function onEnter() {
+		measure();
+		grid?.style.setProperty('--torch', '1');
+	}
+</script>
+
+<svelte:window onresize={measure} onscroll={() => (rects = [])} />
+
+<!-- svelte-ignore a11y_no_static_element_interactions -->
+<div
+	class="grid lab-grid-bg"
+	bind:this={grid}
+	onpointermove={onMove}
+	onpointerenter={onEnter}
+	onpointerleave={onLeave}
+>
+	<div class="torch" aria-hidden="true"></div>
+	{#each cards as card (card.title)}
+		<a class="card" href={card.href}>
+			<span class="border" aria-hidden="true"></span>
+			<span class="wash" aria-hidden="true"></span>
+			<span class="card-inner">
+				<span class="material-symbols-rounded icon" aria-hidden="true">{card.icon}</span>
+				<span class="title" data-preserve-case>{card.title}</span>
+				<span class="body">{card.body}</span>
+				<span class="meta lab-mono">{card.meta}</span>
+			</span>
+		</a>
+	{/each}
+</div>
+
+<style lang="scss">
+	.grid {
+		--gx: 50%;
+		--gy: 50%;
+		--torch: 0;
+		position: relative;
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(230px, 100%), 1fr));
+		gap: 1px;
+		padding: 1px;
+		border-radius: var(--radius-md);
+		background: var(--lab-hairline);
+		overflow: hidden;
+	}
+
+	// A single soft light that lives above the tiles and below the text.
+	.torch {
+		position: absolute;
+		inset: 0;
+		z-index: 2;
+		pointer-events: none;
+		opacity: var(--torch);
+		transition: opacity 350ms ease;
+		background: radial-gradient(
+			240px 240px at var(--gx) var(--gy),
+			color-mix(in srgb, var(--lab-accent) 16%, transparent),
+			transparent 70%
+		);
+		mix-blend-mode: plus-lighter;
+	}
+
+	.card {
+		--x: 50%;
+		--y: 50%;
+		--near: 0;
+		position: relative;
+		display: block;
+		padding: 1px;
+		background: var(--color-surface);
+		text-decoration: none;
+		color: inherit;
+		isolation: isolate;
+		transition: background 300ms ease;
+	}
+
+	// Gradient border: a full-bleed conic-ish wash masked to a 1px ring, faded
+	// in by proximity so only the cards near the cursor light their edge.
+	.border {
+		position: absolute;
+		inset: 0;
+		z-index: 1;
+		pointer-events: none;
+		opacity: var(--near);
+		background: radial-gradient(
+			200px 200px at var(--x) var(--y),
+			var(--lab-accent),
+			transparent 65%
+		);
+		-webkit-mask:
+			linear-gradient(#000 0 0) content-box,
+			linear-gradient(#000 0 0);
+		mask:
+			linear-gradient(#000 0 0) content-box,
+			linear-gradient(#000 0 0);
+		-webkit-mask-composite: xor;
+		mask-composite: exclude;
+		padding: 1px;
+	}
+
+	.wash {
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		opacity: calc(var(--near) * 0.55);
+		background: radial-gradient(
+			260px 200px at var(--x) var(--y),
+			color-mix(in srgb, var(--lab-accent) 12%, transparent),
+			transparent 68%
+		);
+	}
+
+	.card-inner {
+		position: relative;
+		z-index: 3;
+		display: grid;
+		gap: 0.42rem;
+		align-content: start;
+		height: 100%;
+		padding: clamp(1.1rem, 2.4vw, 1.6rem);
+	}
+
+	.icon {
+		font-size: 1.35rem;
+		color: color-mix(in srgb, var(--lab-accent) calc(40% + var(--near) * 60%), var(--color-subtle));
+		transform: translateY(calc(var(--near) * -2px));
+		transition: color 200ms ease;
+	}
+
+	.title {
+		font-family: var(--font-ui);
+		font-size: 1.05rem;
+		font-weight: 650;
+		letter-spacing: -0.02em;
+		color: var(--color-heading);
+	}
+
+	.body {
+		font-size: 0.88rem;
+		line-height: 1.55;
+		color: var(--color-subtle);
+	}
+
+	.meta {
+		margin-top: 0.35rem;
+		font-size: 0.58rem;
+		color: color-mix(in srgb, var(--lab-accent) calc(var(--near) * 100%), var(--color-subtle));
+	}
+
+	@media (hover: none) {
+		.torch {
+			display: none;
+		}
+
+		.card {
+			--near: 0.25;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/StatsStrip.svelte
+++ b/personal-website/src/routes/lab/concepts/StatsStrip.svelte
@@ -1,0 +1,138 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { bookNotes, photoTrips } from '$lib/content';
+
+	const photoCount = photoTrips.reduce((sum, trip) => sum + trip.images.length, 0);
+
+	type Stat = { value: number; label: string; suffix?: string; series: number[] };
+
+	// Sparkline series are deterministic — derived from the data, not random —
+	// so the strip renders identically on the server and after hydration.
+	const stats: Stat[] = [
+		{
+			value: bookNotes.length,
+			label: 'book notes',
+			series: bookNotes.slice(0, 12).map((book) => Number.parseFloat(book.rating) || 5)
+		},
+		{
+			value: photoCount,
+			label: 'photographs',
+			series: photoTrips.slice(0, 12).map((trip) => trip.images.length)
+		},
+		{
+			value: photoTrips.length,
+			label: 'trips',
+			series: photoTrips.slice(0, 12).map((trip) => trip.year - 2018)
+		},
+		{ value: 5, label: 'site rebuilds', series: [1, 1, 2, 2, 3, 4, 4, 5, 5, 5, 5, 5] }
+	];
+
+	let host = $state<HTMLDivElement>();
+	let shown = $state(stats.map(() => 0));
+
+	onMount(() => {
+		if (!host) return;
+
+		const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+		if (reduce) {
+			shown = stats.map((stat) => stat.value);
+			return;
+		}
+
+		let raf = 0;
+		const io = new IntersectionObserver(
+			([entry]) => {
+				if (!entry.isIntersecting) return;
+				io.disconnect();
+
+				const start = performance.now();
+				const DURATION = 1100;
+
+				const tick = (now: number) => {
+					const t = Math.min(1, (now - start) / DURATION);
+					// Ease-out quart: fast off the mark, long settle on the final digit.
+					const eased = 1 - Math.pow(1 - t, 4);
+					shown = stats.map((stat) => Math.round(stat.value * eased));
+					if (t < 1) raf = requestAnimationFrame(tick);
+				};
+				raf = requestAnimationFrame(tick);
+			},
+			{ threshold: 0.4 }
+		);
+		io.observe(host);
+
+		return () => {
+			io.disconnect();
+			if (raf) cancelAnimationFrame(raf);
+		};
+	});
+
+	/** Series → an SVG polyline path across a 100×28 box. */
+	function spark(series: number[]) {
+		if (series.length < 2) return '';
+		const min = Math.min(...series);
+		const max = Math.max(...series);
+		const span = max - min || 1;
+		return series
+			.map((value, i) => {
+				const x = (i / (series.length - 1)) * 100;
+				const y = 26 - ((value - min) / span) * 24;
+				return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)} ${y.toFixed(1)}`;
+			})
+			.join(' ');
+	}
+</script>
+
+<div class="strip" bind:this={host}>
+	{#each stats as stat, i (stat.label)}
+		<div class="stat">
+			<span class="value" data-preserve-case>{shown[i]}</span>
+			<span class="label lab-mono">{stat.label}</span>
+			<svg class="spark" viewBox="0 0 100 28" preserveAspectRatio="none" aria-hidden="true">
+				<path d={spark(stat.series)} fill="none" stroke="currentColor" stroke-width="1.5" />
+			</svg>
+		</div>
+	{/each}
+</div>
+
+<style lang="scss">
+	.strip {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(min(150px, 100%), 1fr));
+		gap: 1px;
+		background: var(--lab-hairline);
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-md);
+		overflow: hidden;
+	}
+
+	.stat {
+		display: grid;
+		gap: 0.2rem;
+		padding: clamp(1rem, 2.4vw, 1.4rem);
+		background: var(--color-surface);
+	}
+
+	.value {
+		font-family: var(--font-ui);
+		font-size: clamp(1.9rem, 4vw, 2.7rem);
+		font-weight: 700;
+		letter-spacing: -0.045em;
+		line-height: 1;
+		color: var(--color-heading);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.label {
+		font-size: 0.56rem;
+		color: var(--color-subtle);
+	}
+
+	.spark {
+		width: 100%;
+		height: 26px;
+		margin-top: 0.35rem;
+		color: color-mix(in srgb, var(--lab-accent) 55%, transparent);
+		overflow: visible;
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/StatusOrb.svelte
+++ b/personal-website/src/routes/lab/concepts/StatusOrb.svelte
@@ -1,0 +1,450 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	const ZONE = 'Australia/Melbourne';
+	const LAT = -37.8136;
+	const LNG = 144.9631;
+
+	const statuses = [
+		{ icon: 'menu_book', label: 'reading', value: 'Thinking, Fast and Slow' },
+		{ icon: 'code', label: 'building', value: 'this site, again' },
+		{ icon: 'directions_run', label: 'training for', value: 'a half, slowly' },
+		{ icon: 'photo_camera', label: 'shooting', value: 'Sony α6700 · 35mm' }
+	];
+
+	// Rendered blank until mount: a server-rendered clock would bake the build
+	// machine's time into the HTML and then visibly jump on hydration.
+	let now = $state<Date | null>(null);
+	let rotating = $state(0);
+
+	onMount(() => {
+		now = new Date();
+		const clock = setInterval(() => (now = new Date()), 1000);
+		const cycle = setInterval(() => (rotating = (rotating + 1) % statuses.length), 4200);
+		return () => {
+			clearInterval(clock);
+			clearInterval(cycle);
+		};
+	});
+
+	/** Minutes past local midnight in Melbourne, and the zone's UTC offset. */
+	function zoneParts(date: Date) {
+		const formatter = new Intl.DateTimeFormat('en-AU', {
+			timeZone: ZONE,
+			hour: '2-digit',
+			minute: '2-digit',
+			second: '2-digit',
+			hour12: false
+		});
+		const parts = Object.fromEntries(
+			formatter.formatToParts(date).map((part) => [part.type, part.value])
+		);
+		const hour = Number(parts.hour ?? 0) % 24;
+		const minute = Number(parts.minute ?? 0);
+		const second = Number(parts.second ?? 0);
+
+		const offsetName =
+			new Intl.DateTimeFormat('en-AU', { timeZone: ZONE, timeZoneName: 'shortOffset' })
+				.formatToParts(date)
+				.find((part) => part.type === 'timeZoneName')?.value ?? 'GMT+10';
+		const match = /GMT([+-])(\d{1,2})(?::(\d{2}))?/.exec(offsetName);
+		const sign = match?.[1] === '-' ? -1 : 1;
+		const offset = match ? sign * (Number(match[2]) * 60 + Number(match[3] ?? 0)) : 600;
+
+		return { hour, minute, second, minutes: hour * 60 + minute + second / 60, offset };
+	}
+
+	/**
+	 * NOAA's sunrise/sunset approximation. Accurate to about a minute, which is
+	 * plenty for drawing an arc, and avoids shipping a date library for it.
+	 */
+	function solar(date: Date, offsetMinutes: number) {
+		const start = Date.UTC(date.getUTCFullYear(), 0, 0);
+		const dayOfYear = Math.floor((date.getTime() - start) / 86400000);
+		const gamma = ((2 * Math.PI) / 365) * (dayOfYear - 1 + 0.5);
+
+		const eqTime =
+			229.18 *
+			(0.000075 +
+				0.001868 * Math.cos(gamma) -
+				0.032077 * Math.sin(gamma) -
+				0.014615 * Math.cos(2 * gamma) -
+				0.040849 * Math.sin(2 * gamma));
+
+		const decl =
+			0.006918 -
+			0.399912 * Math.cos(gamma) +
+			0.070257 * Math.sin(gamma) -
+			0.006758 * Math.cos(2 * gamma) +
+			0.000907 * Math.sin(2 * gamma) -
+			0.002697 * Math.cos(3 * gamma) +
+			0.00148 * Math.sin(3 * gamma);
+
+		const lat = (LAT * Math.PI) / 180;
+		const cosHa =
+			Math.cos((90.833 * Math.PI) / 180) / (Math.cos(lat) * Math.cos(decl)) -
+			Math.tan(lat) * Math.tan(decl);
+
+		// Polar day / polar night — never happens at this latitude, but the guard
+		// keeps `acos` from returning NaN if the coordinates are ever changed.
+		if (cosHa > 1) return { sunrise: 0, sunset: 0 };
+		if (cosHa < -1) return { sunrise: 0, sunset: 1440 };
+
+		const ha = (Math.acos(cosHa) * 180) / Math.PI;
+		const wrap = (m: number) => ((m % 1440) + 1440) % 1440;
+
+		return {
+			sunrise: wrap(720 - 4 * (LNG + ha) - eqTime + offsetMinutes),
+			sunset: wrap(720 - 4 * (LNG - ha) - eqTime + offsetMinutes)
+		};
+	}
+
+	const clock = $derived(now ? zoneParts(now) : null);
+	const sun = $derived(now && clock ? solar(now, clock.offset) : null);
+
+	const daylight = $derived.by(() => {
+		if (!clock || !sun) return null;
+		const span = sun.sunset - sun.sunrise;
+		const through = (clock.minutes - sun.sunrise) / span;
+		return {
+			up: through >= 0 && through <= 1,
+			through: Math.min(1, Math.max(0, through)),
+			hours: Math.floor(span / 60),
+			minutes: Math.round(span % 60)
+		};
+	});
+
+	function hhmm(minutes: number) {
+		const h = Math.floor(minutes / 60) % 24;
+		const m = Math.round(minutes % 60) % 60;
+		return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+	}
+
+	// The sun's position along a 180° arc of radius 90, centred at (100, 100).
+	const marker = $derived.by(() => {
+		const t = daylight?.through ?? 0;
+		const angle = Math.PI * (1 - t);
+		return { x: 100 + Math.cos(angle) * 90, y: 100 - Math.sin(angle) * 90 };
+	});
+</script>
+
+<div class="orb-card" class:night={daylight ? !daylight.up : false}>
+	<div class="left">
+		<div class="pulse" aria-hidden="true">
+			<span class="ring r1"></span>
+			<span class="ring r2"></span>
+			<span class="core"></span>
+		</div>
+		<div class="place">
+			<span class="city" data-preserve-case>Melbourne</span>
+			<span class="coords lab-mono">37.81° S · 144.96° E</span>
+		</div>
+	</div>
+
+	<div class="clock">
+		{#if clock}
+			<span class="time" data-preserve-case>
+				{String(clock.hour).padStart(2, '0')}<span class="colon">:</span>{String(
+					clock.minute
+				).padStart(2, '0')}
+				<span class="secs lab-mono">{String(clock.second).padStart(2, '0')}</span>
+			</span>
+			<span class="zone lab-mono">
+				{daylight?.up ? 'daylight' : 'after dark'} · utc{clock.offset >= 0 ? '+' : ''}{(
+					clock.offset / 60
+				).toFixed(clock.offset % 60 ? 1 : 0)}
+			</span>
+		{:else}
+			<span class="time skeleton" aria-hidden="true">--:--</span>
+			<span class="zone lab-mono">syncing…</span>
+		{/if}
+	</div>
+
+	<div class="arc">
+		<svg viewBox="0 0 200 118" aria-hidden="true">
+			<defs>
+				<linearGradient id="orb-sky" x1="0" y1="0" x2="1" y2="0">
+					<stop offset="0%" stop-color="var(--lab-accent)" stop-opacity="0.15" />
+					<stop offset="50%" stop-color="var(--lab-accent)" stop-opacity="0.9" />
+					<stop offset="100%" stop-color="var(--lab-accent)" stop-opacity="0.15" />
+				</linearGradient>
+			</defs>
+			<path
+				d="M10 100 A 90 90 0 0 1 190 100"
+				fill="none"
+				stroke="url(#orb-sky)"
+				stroke-width="2"
+				stroke-linecap="round"
+				stroke-dasharray="1 5"
+			/>
+			<line x1="4" y1="100" x2="196" y2="100" stroke="var(--lab-hairline)" stroke-width="1" />
+			{#if daylight}
+				<circle class="sun" cx={marker.x} cy={marker.y} r="7" />
+				<circle class="sun-halo" cx={marker.x} cy={marker.y} r="13" />
+			{/if}
+		</svg>
+		<div class="arc-labels lab-mono">
+			<span>↑ {sun ? hhmm(sun.sunrise) : '--:--'}</span>
+			<span>
+				{daylight ? `${daylight.hours}h ${daylight.minutes}m of light` : ''}
+			</span>
+			<span>{sun ? hhmm(sun.sunset) : '--:--'} ↓</span>
+		</div>
+	</div>
+
+	<div class="status">
+		{#each statuses as item, i (item.label)}
+			<div class="status-line" class:on={i === rotating}>
+				<span class="material-symbols-rounded" aria-hidden="true">{item.icon}</span>
+				<span class="status-label lab-mono">{item.label}</span>
+				<span class="status-value" data-preserve-case>{item.value}</span>
+			</div>
+		{/each}
+	</div>
+</div>
+
+<style lang="scss">
+	.orb-card {
+		display: grid;
+		grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+		grid-template-areas:
+			'left clock'
+			'arc arc'
+			'status status';
+		gap: clamp(0.9rem, 2.5vw, 1.5rem);
+		padding: clamp(1.1rem, 2.6vw, 1.75rem);
+		border-radius: var(--radius-lg);
+		background: linear-gradient(
+			160deg,
+			color-mix(in srgb, var(--lab-accent) 10%, var(--color-surface)),
+			var(--color-surface) 55%
+		);
+		border: 1px solid var(--lab-hairline);
+		transition: background 900ms ease;
+	}
+
+	.orb-card.night {
+		background: linear-gradient(
+			160deg,
+			color-mix(in srgb, #2b3a6b 22%, var(--color-surface)),
+			var(--color-surface) 60%
+		);
+	}
+
+	.left {
+		grid-area: left;
+		display: flex;
+		align-items: center;
+		gap: 0.8rem;
+	}
+
+	.pulse {
+		position: relative;
+		width: 34px;
+		height: 34px;
+		flex: 0 0 auto;
+	}
+
+	.core,
+	.ring {
+		position: absolute;
+		inset: 0;
+		margin: auto;
+		border-radius: 999px;
+	}
+
+	.core {
+		width: 12px;
+		height: 12px;
+		background: var(--lab-accent);
+		box-shadow: 0 0 14px color-mix(in srgb, var(--lab-accent) 70%, transparent);
+	}
+
+	.ring {
+		width: 12px;
+		height: 12px;
+		border: 1.5px solid var(--lab-accent);
+		opacity: 0;
+		animation: breathe 3.2s ease-out infinite;
+	}
+
+	.r2 {
+		animation-delay: 1.6s;
+	}
+
+	@keyframes breathe {
+		0% {
+			transform: scale(1);
+			opacity: 0.7;
+		}
+		100% {
+			transform: scale(2.9);
+			opacity: 0;
+		}
+	}
+
+	.place {
+		display: grid;
+		gap: 0.1rem;
+		min-width: 0;
+	}
+
+	.city {
+		font-family: var(--font-ui);
+		font-size: 1rem;
+		font-weight: 650;
+		letter-spacing: -0.02em;
+		color: var(--color-heading);
+	}
+
+	.coords {
+		font-size: 0.52rem;
+		color: var(--color-subtle);
+	}
+
+	.clock {
+		grid-area: clock;
+		display: grid;
+		justify-items: end;
+		gap: 0.15rem;
+	}
+
+	.time {
+		display: flex;
+		align-items: baseline;
+		gap: 0.25rem;
+		font-family: var(--font-ui);
+		font-size: clamp(1.7rem, 4.5vw, 2.6rem);
+		font-weight: 700;
+		letter-spacing: -0.04em;
+		line-height: 1;
+		color: var(--color-heading);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.time.skeleton {
+		opacity: 0.25;
+	}
+
+	.colon {
+		animation: blink 2s steps(1) infinite;
+	}
+
+	@keyframes blink {
+		50% {
+			opacity: 0.25;
+		}
+	}
+
+	.secs {
+		font-size: 0.7rem;
+		color: var(--lab-accent);
+		letter-spacing: 0.05em;
+	}
+
+	.zone {
+		font-size: 0.52rem;
+		color: var(--color-subtle);
+	}
+
+	.arc {
+		grid-area: arc;
+		display: grid;
+		gap: 0.35rem;
+	}
+
+	// The 200×118 viewBox scales to its container, so without a cap the arc grows
+	// as tall as the card is wide. Bound the width and centre it instead.
+	.arc svg {
+		display: block;
+		width: 100%;
+		max-width: 420px;
+		height: auto;
+		margin-inline: auto;
+		overflow: visible;
+	}
+
+	.sun {
+		fill: var(--lab-accent);
+		transition:
+			cx 800ms ease,
+			cy 800ms ease;
+	}
+
+	.sun-halo {
+		fill: var(--lab-accent);
+		opacity: 0.16;
+		transition:
+			cx 800ms ease,
+			cy 800ms ease;
+	}
+
+	.arc-labels {
+		display: flex;
+		justify-content: space-between;
+		gap: 0.5rem;
+		width: 100%;
+		max-width: 440px;
+		margin-inline: auto;
+		font-size: 0.52rem;
+		color: var(--color-subtle);
+	}
+
+	.status {
+		grid-area: status;
+		position: relative;
+		height: 2.4rem;
+		border-top: 1px solid var(--lab-hairline);
+		padding-top: 0.7rem;
+	}
+
+	.status-line {
+		position: absolute;
+		inset: 0.7rem 0 0;
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		opacity: 0;
+		transform: translateY(8px);
+		transition:
+			opacity 420ms ease,
+			transform 420ms ease;
+		pointer-events: none;
+	}
+
+	.status-line.on {
+		opacity: 1;
+		transform: none;
+	}
+
+	.status-line .material-symbols-rounded {
+		font-size: 1.05rem;
+		color: var(--lab-accent);
+	}
+
+	.status-label {
+		font-size: 0.52rem;
+		color: var(--color-subtle);
+	}
+
+	.status-value {
+		font-size: 0.92rem;
+		font-weight: 550;
+		color: var(--color-heading);
+	}
+
+	@media (max-width: 520px) {
+		.orb-card {
+			grid-template-columns: minmax(0, 1fr);
+			grid-template-areas:
+				'left'
+				'clock'
+				'arc'
+				'status';
+		}
+
+		.clock {
+			justify-items: start;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/TextTreatments.svelte
+++ b/personal-website/src/routes/lab/concepts/TextTreatments.svelte
@@ -1,0 +1,249 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	const GLYPHS = '▓▒░#@%&$*+=-_/\\|<>[]{}';
+	const PHRASE = 'Notes from a slow web';
+
+	let scrambled = $state(PHRASE);
+	let highlightOn = $state(false);
+	let blurOn = $state(false);
+	let host = $state<HTMLDivElement>();
+
+	const blurWords = 'Everything here is hand-made, on purpose, and rarely finished.'.split(' ');
+
+	function runScramble() {
+		const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+		if (reduce) {
+			scrambled = PHRASE;
+			return;
+		}
+
+		const target = PHRASE.split('');
+		// Each character gets its own reveal frame, so the phrase resolves left to
+		// right with a ragged edge instead of snapping all at once.
+		const settleAt = target.map((_, i) => 8 + i * 2.2 + Math.random() * 10);
+		let frame = 0;
+		let raf = 0;
+
+		const tick = () => {
+			const out = target.map((char, i) => {
+				if (char === ' ') return ' ';
+				if (frame >= settleAt[i]) return char;
+				return GLYPHS[Math.floor(Math.random() * GLYPHS.length)];
+			});
+			scrambled = out.join('');
+			frame++;
+			if (frame <= Math.max(...settleAt) + 1) raf = requestAnimationFrame(tick);
+		};
+
+		raf = requestAnimationFrame(tick);
+		return () => cancelAnimationFrame(raf);
+	}
+
+	onMount(() => {
+		if (!host) return;
+		let cancelScramble: (() => void) | undefined;
+
+		const io = new IntersectionObserver(
+			([entry]) => {
+				if (!entry.isIntersecting) return;
+				cancelScramble = runScramble();
+				setTimeout(() => (highlightOn = true), 260);
+				setTimeout(() => (blurOn = true), 120);
+				io.disconnect();
+			},
+			{ threshold: 0.35 }
+		);
+		io.observe(host);
+
+		return () => {
+			io.disconnect();
+			cancelScramble?.();
+		};
+	});
+
+	function replay() {
+		highlightOn = false;
+		blurOn = false;
+		requestAnimationFrame(() => {
+			runScramble();
+			highlightOn = true;
+			blurOn = true;
+		});
+	}
+</script>
+
+<div class="treatments" bind:this={host}>
+	<div class="row">
+		<span class="tag lab-mono">01 · decode</span>
+		<h4 class="scramble" aria-label={PHRASE}>
+			<span aria-hidden="true">{scrambled}</span>
+		</h4>
+	</div>
+
+	<div class="row">
+		<span class="tag lab-mono">02 · marker</span>
+		<p class="marker">
+			I write these notes
+			<span class="mark" class:on={highlightOn}>
+				<span class="mark-text">mostly for myself</span>
+				<!-- A hand-drawn marker stroke: two overlapping strokes with a slight
+				     wobble, drawn on with stroke-dashoffset. -->
+				<svg viewBox="0 0 300 40" preserveAspectRatio="none" aria-hidden="true">
+					<path
+						d="M4 27 C 60 19, 120 33, 180 24 S 262 18, 296 26"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="19"
+						stroke-linecap="round"
+					/>
+					<path
+						d="M10 33 C 70 28, 140 38, 210 30 S 268 27, 292 32"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="9"
+						stroke-linecap="round"
+						opacity="0.55"
+					/>
+				</svg>
+			</span>
+			— the fact you are reading them is a happy accident.
+		</p>
+	</div>
+
+	<div class="row">
+		<span class="tag lab-mono">03 · focus pull</span>
+		<p class="blur" class:on={blurOn}>
+			{#each blurWords as word, i (i)}
+				<span style={`--d:${i * 55}ms`}>{word}</span>{' '}
+			{/each}
+		</p>
+	</div>
+
+	<button class="replay lab-mono" type="button" onclick={replay}>replay ↺</button>
+</div>
+
+<style lang="scss">
+	.treatments {
+		display: grid;
+		gap: clamp(1.4rem, 3vw, 2.2rem);
+	}
+
+	.row {
+		display: grid;
+		grid-template-columns: 6.5rem minmax(0, 1fr);
+		gap: 1rem;
+		align-items: baseline;
+	}
+
+	.tag {
+		font-size: 0.55rem;
+		color: var(--lab-accent);
+		opacity: 0.85;
+	}
+
+	.scramble {
+		margin: 0;
+		font-family: var(--lab-mono);
+		font-size: clamp(1.15rem, 3vw, 2rem);
+		font-weight: 500;
+		letter-spacing: -0.01em;
+		color: var(--color-heading);
+		// Fixed advance width keeps the line from reflowing while it resolves.
+		font-variant-ligatures: none;
+		white-space: pre;
+		overflow-x: hidden;
+	}
+
+	.marker,
+	.blur {
+		margin: 0;
+		font-size: clamp(1rem, 1.6vw, 1.2rem);
+		line-height: 1.7;
+		color: var(--color-ink);
+	}
+
+	.mark {
+		position: relative;
+		display: inline-block;
+		color: color-mix(in srgb, var(--lab-accent) 55%, transparent);
+		white-space: nowrap;
+	}
+
+	.mark-text {
+		position: relative;
+		z-index: 1;
+		color: var(--color-heading);
+		font-weight: 600;
+	}
+
+	.mark svg {
+		position: absolute;
+		left: -0.35em;
+		right: -0.35em;
+		top: 0.05em;
+		width: calc(100% + 0.7em);
+		height: 1.15em;
+		z-index: 0;
+	}
+
+	.mark path {
+		stroke-dasharray: 320;
+		stroke-dashoffset: 320;
+	}
+
+	.mark.on path {
+		animation: draw 620ms cubic-bezier(0.5, 0, 0.2, 1) forwards;
+	}
+
+	.mark.on path:nth-child(2) {
+		animation-delay: 120ms;
+	}
+
+	@keyframes draw {
+		to {
+			stroke-dashoffset: 0;
+		}
+	}
+
+	.blur span {
+		display: inline-block;
+		opacity: 0;
+		filter: blur(8px);
+		transform: translateY(6px);
+	}
+
+	.blur.on span {
+		animation: focus 620ms cubic-bezier(0.2, 0.8, 0.3, 1) var(--d) forwards;
+	}
+
+	@keyframes focus {
+		to {
+			opacity: 1;
+			filter: blur(0);
+			transform: none;
+		}
+	}
+
+	.replay {
+		justify-self: start;
+		margin-left: 7.5rem;
+		padding: 0.35rem 0.7rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 999px;
+		background: var(--color-surface);
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+	}
+
+	@media (max-width: 620px) {
+		.row {
+			grid-template-columns: 1fr;
+			gap: 0.35rem;
+		}
+
+		.replay {
+			margin-left: 0;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/ThemeStudio.svelte
+++ b/personal-website/src/routes/lab/concepts/ThemeStudio.svelte
@@ -1,0 +1,372 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	let hue = $state(146);
+	let chroma = $state(0.14);
+	let warmth = $state(0.014);
+	let radius = $state(12);
+	let live = $state(false);
+	let copied = $state(false);
+	let dark = $state(false);
+
+	// Every token below is derived from four numbers, which is the point of the
+	// demo: a whole palette is a function, not a list of hex codes.
+	const tokens = $derived.by(() => {
+		const l = dark ? 0.7 : 0.6;
+		return {
+			'--color-green': `oklch(${l} ${chroma.toFixed(3)} ${hue})`,
+			'--color-green-soft': `oklch(${(l + 0.1).toFixed(2)} ${(chroma * 0.62).toFixed(3)} ${hue})`,
+			'--color-cream': dark
+				? `oklch(0.19 ${(warmth * 0.6).toFixed(3)} ${hue})`
+				: `oklch(0.975 ${warmth.toFixed(3)} ${hue})`,
+			'--color-surface': dark
+				? `oklch(0.22 ${(warmth * 0.6).toFixed(3)} ${hue})`
+				: `oklch(0.99 ${(warmth * 0.7).toFixed(3)} ${hue})`,
+			'--color-muted': dark
+				? `oklch(0.25 ${(warmth * 0.8).toFixed(3)} ${hue})`
+				: `oklch(0.945 ${(warmth * 1.4).toFixed(3)} ${hue})`,
+			'--color-muted-strong': dark
+				? `oklch(0.31 ${(warmth * 0.9).toFixed(3)} ${hue})`
+				: `oklch(0.9 ${(warmth * 1.8).toFixed(3)} ${hue})`,
+			'--radius-sm': `${(radius * 0.25).toFixed(0)}px`,
+			'--radius-md': `${(radius * 0.6).toFixed(0)}px`,
+			'--radius-lg': `${radius}px`
+		} satisfies Record<string, string>;
+	});
+
+	const css = $derived(
+		`:root {\n${Object.entries(tokens)
+			.map(([key, value]) => `\t${key}: ${value};`)
+			.join('\n')}\n}`
+	);
+
+	onMount(() => {
+		dark = document.documentElement.dataset.theme === 'dark';
+		const observer = new MutationObserver(() => {
+			dark = document.documentElement.dataset.theme === 'dark';
+		});
+		observer.observe(document.documentElement, {
+			attributes: true,
+			attributeFilter: ['data-theme']
+		});
+		return () => {
+			observer.disconnect();
+			clear();
+		};
+	});
+
+	function clear() {
+		const root = document.documentElement;
+		for (const key of Object.keys(tokens)) root.style.removeProperty(key);
+	}
+
+	// Inline custom properties on <html> out-specify every stylesheet rule, so
+	// this repaints the real header, footer and page chrome — not just a swatch.
+	$effect(() => {
+		if (typeof document === 'undefined') return;
+		const root = document.documentElement;
+		if (!live) {
+			clear();
+			return;
+		}
+		for (const [key, value] of Object.entries(tokens)) root.style.setProperty(key, value);
+	});
+
+	function reset() {
+		hue = 146;
+		chroma = 0.14;
+		warmth = 0.014;
+		radius = 12;
+	}
+
+	async function copy() {
+		try {
+			await navigator.clipboard.writeText(css);
+			copied = true;
+			setTimeout(() => (copied = false), 1600);
+		} catch {
+			copied = false;
+		}
+	}
+</script>
+
+<div
+	class="studio"
+	style={Object.entries(tokens)
+		.map(([k, v]) => `${k}:${v}`)
+		.join(';')}
+>
+	<div class="controls">
+		<label class="control">
+			<span class="lab-mono">accent hue <b>{hue}°</b></span>
+			<input class="hue" type="range" min="0" max="360" step="1" bind:value={hue} />
+		</label>
+
+		<label class="control">
+			<span class="lab-mono">chroma <b>{chroma.toFixed(3)}</b></span>
+			<input type="range" min="0" max="0.24" step="0.005" bind:value={chroma} />
+		</label>
+
+		<label class="control">
+			<span class="lab-mono">paper warmth <b>{warmth.toFixed(3)}</b></span>
+			<input type="range" min="0" max="0.045" step="0.001" bind:value={warmth} />
+		</label>
+
+		<label class="control">
+			<span class="lab-mono">corner radius <b>{radius}px</b></span>
+			<input type="range" min="0" max="26" step="1" bind:value={radius} />
+		</label>
+
+		<div class="row">
+			<button class="toggle" class:on={live} type="button" onclick={() => (live = !live)}>
+				<span class="dot"></span>
+				{live ? 'Applied site-wide' : 'Apply to the whole page'}
+			</button>
+			<button class="ghost" type="button" onclick={reset}>Reset</button>
+		</div>
+	</div>
+
+	<div class="preview">
+		<div class="swatches">
+			<span class="sw" style="background:var(--color-green)"></span>
+			<span class="sw" style="background:var(--color-green-soft)"></span>
+			<span class="sw" style="background:var(--color-muted-strong)"></span>
+			<span class="sw" style="background:var(--color-muted)"></span>
+			<span class="sw" style="background:var(--color-surface)"></span>
+		</div>
+
+		<div class="mock">
+			<span class="mock-eyebrow lab-mono">book note</span>
+			<h4 data-preserve-case>Born To Run</h4>
+			<p>Humans were born with the innate capacity to run long distances.</p>
+			<div class="mock-actions">
+				<span class="mock-btn primary">Read notes</span>
+				<span class="mock-btn ghost">Buy</span>
+			</div>
+		</div>
+
+		<div class="code">
+			<button class="copy lab-mono" type="button" onclick={copy}>
+				{copied ? 'copied ✓' : 'copy css'}
+			</button>
+			<pre>{css}</pre>
+		</div>
+	</div>
+</div>
+
+<style lang="scss">
+	.studio {
+		display: grid;
+		grid-template-columns: minmax(220px, 300px) minmax(0, 1fr);
+		gap: clamp(1rem, 3vw, 2rem);
+		align-items: start;
+	}
+
+	.controls {
+		display: grid;
+		gap: 1rem;
+	}
+
+	.control {
+		display: grid;
+		gap: 0.4rem;
+	}
+
+	.control span {
+		font-size: 0.58rem;
+		color: var(--color-subtle);
+	}
+
+	.control b {
+		color: var(--color-heading);
+		font-variant-numeric: tabular-nums;
+	}
+
+	input[type='range'] {
+		-webkit-appearance: none;
+		appearance: none;
+		width: 100%;
+		height: 6px;
+		border-radius: 999px;
+		background: var(--color-muted-strong);
+		outline: none;
+	}
+
+	input[type='range'].hue {
+		// Full oklch sweep so the slider itself is the colour picker.
+		background: linear-gradient(
+			90deg,
+			oklch(0.62 0.16 0),
+			oklch(0.62 0.16 60),
+			oklch(0.62 0.16 120),
+			oklch(0.62 0.16 180),
+			oklch(0.62 0.16 240),
+			oklch(0.62 0.16 300),
+			oklch(0.62 0.16 360)
+		);
+	}
+
+	input[type='range']::-webkit-slider-thumb {
+		-webkit-appearance: none;
+		width: 16px;
+		height: 16px;
+		border-radius: 999px;
+		border: 2px solid var(--color-surface);
+		background: var(--color-green);
+		box-shadow: 0 1px 4px rgb(0 0 0 / 0.3);
+		cursor: grab;
+	}
+
+	input[type='range']::-moz-range-thumb {
+		width: 14px;
+		height: 14px;
+		border-radius: 999px;
+		border: 2px solid var(--color-surface);
+		background: var(--color-green);
+		cursor: grab;
+	}
+
+	.row {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.toggle,
+	.ghost {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		padding: 0.5rem 0.85rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: 999px;
+		background: var(--color-surface);
+		font-family: var(--font-ui);
+		font-size: 0.78rem;
+		font-weight: 600;
+		color: var(--color-heading);
+	}
+
+	.toggle.on {
+		border-color: var(--color-green);
+		background: color-mix(in srgb, var(--color-green) 14%, transparent);
+	}
+
+	.dot {
+		width: 7px;
+		height: 7px;
+		border-radius: 999px;
+		background: var(--color-muted-strong);
+	}
+
+	.toggle.on .dot {
+		background: var(--color-green);
+		box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-green) 25%, transparent);
+	}
+
+	.preview {
+		display: grid;
+		gap: 0.85rem;
+	}
+
+	.swatches {
+		display: flex;
+		gap: 4px;
+		height: 44px;
+	}
+
+	.sw {
+		flex: 1;
+		border-radius: var(--radius-md);
+		border: 1px solid var(--lab-hairline);
+	}
+
+	.mock {
+		display: grid;
+		gap: 0.4rem;
+		padding: 1.1rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-lg);
+		background: var(--color-surface);
+	}
+
+	.mock-eyebrow {
+		font-size: 0.55rem;
+		color: var(--color-green);
+	}
+
+	.mock h4 {
+		margin: 0;
+		font-family: var(--font-ui);
+		font-size: 1.15rem;
+		font-weight: 700;
+		letter-spacing: -0.025em;
+	}
+
+	.mock p {
+		margin: 0;
+		font-size: 0.86rem;
+		color: var(--color-subtle);
+	}
+
+	.mock-actions {
+		display: flex;
+		gap: 0.4rem;
+		margin-top: 0.35rem;
+	}
+
+	.mock-btn {
+		padding: 0.4rem 0.85rem;
+		border-radius: 999px;
+		font-family: var(--font-ui);
+		font-size: 0.78rem;
+		font-weight: 600;
+	}
+
+	.mock-btn.primary {
+		background: var(--color-green);
+		color: #fff;
+	}
+
+	.mock-btn.ghost {
+		border: 1px solid var(--color-muted-strong);
+		background: var(--color-muted);
+	}
+
+	.code {
+		position: relative;
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-md);
+		background: var(--color-muted);
+		overflow: hidden;
+	}
+
+	.copy {
+		position: absolute;
+		top: 0.45rem;
+		right: 0.45rem;
+		padding: 0.25rem 0.5rem;
+		border: 1px solid var(--lab-hairline);
+		border-radius: var(--radius-sm);
+		background: var(--color-surface);
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+	}
+
+	pre {
+		margin: 0;
+		padding: 0.85rem 1rem;
+		font-family: var(--lab-mono);
+		font-size: 0.66rem;
+		line-height: 1.7;
+		color: var(--color-subtle);
+		overflow-x: auto;
+		tab-size: 2;
+	}
+
+	@media (max-width: 760px) {
+		.studio {
+			grid-template-columns: 1fr;
+		}
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/VelocityTicker.svelte
+++ b/personal-website/src/routes/lab/concepts/VelocityTicker.svelte
@@ -1,0 +1,170 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	type Props = { items?: string[] };
+	let {
+		items = [
+			'photography',
+			'book notes',
+			'svelte',
+			'long runs',
+			'film cameras',
+			'typography',
+			'melbourne',
+			'side projects'
+		]
+	}: Props = $props();
+
+	// Two identical copies sit end to end so the offset can wrap without a seam.
+	const lane = $derived([...items, ...items]);
+
+	let host = $state<HTMLDivElement>();
+	let trackA = $state<HTMLDivElement>();
+	let trackB = $state<HTMLDivElement>();
+
+	onMount(() => {
+		const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+		if (reduce || !host) return;
+
+		let lastY = window.scrollY;
+		let velocity = 0;
+		let offsetA = 0;
+		let offsetB = 0;
+		let raf = 0;
+		let visible = true;
+
+		function onScroll() {
+			const y = window.scrollY;
+			// Clamped so a flick of the wheel can't fling the lane off-screen.
+			velocity += Math.max(-60, Math.min(60, y - lastY));
+			lastY = y;
+		}
+
+		const io = new IntersectionObserver(
+			([entry]) => {
+				visible = entry.isIntersecting;
+				if (visible && !raf) raf = requestAnimationFrame(frame);
+			},
+			{ threshold: 0 }
+		);
+		io.observe(host);
+
+		// Keep the offset inside (-width, 0] so the seam between the two copies of
+		// the lane never enters the viewport, whichever way the track is moving.
+		function wrap(value: number, width: number) {
+			if (!width) return value;
+			return -(((-value % width) + width) % width);
+		}
+
+		function frame() {
+			raf = 0;
+			if (!visible) return;
+
+			velocity *= 0.9;
+			const drift = 0.55 + velocity * 0.12;
+
+			const widthA = (trackA?.scrollWidth ?? 0) / 2;
+			const widthB = (trackB?.scrollWidth ?? 0) / 2;
+
+			offsetA = wrap(offsetA - drift, widthA);
+			offsetB = wrap(offsetB + drift * 0.72, widthB);
+
+			// Skew and weight ride the same velocity, so the whole band leans into
+			// the scroll and relaxes back to upright when the page settles.
+			const skew = Math.max(-9, Math.min(9, -velocity * 0.28));
+			host?.style.setProperty('--skew', `${skew.toFixed(2)}deg`);
+			host?.style.setProperty('--rush', Math.min(1, Math.abs(velocity) / 34).toFixed(3));
+
+			if (trackA) trackA.style.transform = `translate3d(${offsetA.toFixed(2)}px,0,0)`;
+			if (trackB) trackB.style.transform = `translate3d(${offsetB.toFixed(2)}px,0,0)`;
+
+			raf = requestAnimationFrame(frame);
+		}
+
+		window.addEventListener('scroll', onScroll, { passive: true });
+		raf = requestAnimationFrame(frame);
+
+		return () => {
+			window.removeEventListener('scroll', onScroll);
+			io.disconnect();
+			if (raf) cancelAnimationFrame(raf);
+		};
+	});
+</script>
+
+<div class="ticker" bind:this={host} aria-hidden="true">
+	<div class="lane">
+		<div class="track" bind:this={trackA}>
+			{#each lane as item, i (i)}
+				<span class="word">{item}</span><span class="dot">◆</span>
+			{/each}
+		</div>
+	</div>
+	<div class="lane outline">
+		<div class="track" bind:this={trackB}>
+			{#each lane as item, i (i)}
+				<span class="word">{item}</span><span class="dot">◆</span>
+			{/each}
+		</div>
+	</div>
+</div>
+<p class="sr-only">Interests: {items.join(', ')}.</p>
+
+<style lang="scss">
+	.ticker {
+		--skew: 0deg;
+		--rush: 0;
+		display: grid;
+		gap: 0.2rem;
+		padding: clamp(1rem, 3vw, 2rem) 0;
+		overflow: hidden;
+		transform: skewY(var(--skew));
+		transition: transform 60ms linear;
+	}
+
+	.lane {
+		overflow: hidden;
+		white-space: nowrap;
+	}
+
+	.track {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.9rem;
+		will-change: transform;
+	}
+
+	.word {
+		font-family: var(--lab-kinetic);
+		font-size: clamp(1.8rem, 5.5vw, 3.6rem);
+		line-height: 1.06;
+		letter-spacing: -0.02em;
+		color: var(--color-heading);
+		// Weight and optical size track the scroll rush, so the band physically
+		// thickens as the page moves.
+		font-variation-settings:
+			'wght' calc(340 + 420 * var(--rush)),
+			'opsz' calc(20 + 120 * var(--rush)),
+			'SOFT' calc(80 * var(--rush));
+	}
+
+	.outline .word {
+		color: transparent;
+		-webkit-text-stroke: 1px color-mix(in srgb, var(--color-ink) 38%, transparent);
+	}
+
+	.dot {
+		font-size: clamp(0.5rem, 1.2vw, 0.8rem);
+		color: var(--lab-accent);
+		transform: translateY(-0.45em);
+		opacity: calc(0.35 + 0.65 * var(--rush));
+	}
+
+	.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		overflow: hidden;
+		clip-path: inset(50%);
+	}
+</style>

--- a/personal-website/src/routes/lab/concepts/YearGrid.svelte
+++ b/personal-website/src/routes/lab/concepts/YearGrid.svelte
@@ -1,0 +1,345 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { year2026Timeline } from '$lib/content';
+
+	type Cell = {
+		iso: string;
+		label: string;
+		weekday: number;
+		week: number;
+		level: number;
+		event?: string;
+		future: boolean;
+		today: boolean;
+	};
+
+	const YEAR = 2026;
+
+	const events = new Map(year2026Timeline.map((entry) => [entry.date, entry.title]));
+
+	/**
+	 * Deterministic per-day intensity. A hash rather than `Math.random()` so the
+	 * server render and the hydrated client agree — otherwise the whole grid
+	 * repaints on hydration.
+	 */
+	function intensity(iso: string) {
+		let hash = 2166136261;
+		for (let i = 0; i < iso.length; i++) {
+			hash ^= iso.charCodeAt(i);
+			hash = Math.imul(hash, 16777619);
+		}
+		return ((hash >>> 0) % 1000) / 1000;
+	}
+
+	// `today` is resolved on mount: rendering it during SSR would bake the
+	// server's clock into the markup and mismatch a client in another timezone.
+	let today = $state<string | null>(null);
+	onMount(() => {
+		const now = new Date();
+		today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(
+			now.getDate()
+		).padStart(2, '0')}`;
+	});
+
+	const cells = $derived.by((): Cell[] => {
+		const out: Cell[] = [];
+		const start = new Date(Date.UTC(YEAR, 0, 1));
+		// Sunday-first columns, matching the offset of Jan 1 in the first week.
+		const offset = start.getUTCDay();
+		const days = (Date.UTC(YEAR + 1, 0, 1) - Date.UTC(YEAR, 0, 1)) / 86400000;
+
+		for (let day = 0; day < days; day++) {
+			const date = new Date(Date.UTC(YEAR, 0, 1 + day));
+			const iso = date.toISOString().slice(0, 10);
+			const future = today ? iso > today : false;
+			const raw = intensity(iso);
+
+			out.push({
+				iso,
+				label: date.toLocaleDateString('en-AU', {
+					weekday: 'short',
+					day: 'numeric',
+					month: 'long',
+					timeZone: 'UTC'
+				}),
+				weekday: date.getUTCDay(),
+				week: Math.floor((day + offset) / 7),
+				// Weekends skew quieter; the curve just makes the field read nicely.
+				level: future ? 0 : Math.min(4, Math.floor(raw * (date.getUTCDay() % 6 === 0 ? 3.4 : 5))),
+				event: events.get(iso),
+				future,
+				today: iso === today
+			});
+		}
+		return out;
+	});
+
+	const elapsed = $derived(cells.filter((cell) => !cell.future).length);
+	const percent = $derived(cells.length ? Math.round((elapsed / cells.length) * 1000) / 10 : 0);
+
+	let hovered = $state<Cell | null>(null);
+
+	const months = Array.from({ length: 12 }, (_, m) => ({
+		name: new Date(Date.UTC(YEAR, m, 1)).toLocaleDateString('en-AU', {
+			month: 'short',
+			timeZone: 'UTC'
+		}),
+		week: Math.floor(
+			((Date.UTC(YEAR, m, 1) - Date.UTC(YEAR, 0, 1)) / 86400000 +
+				new Date(Date.UTC(YEAR, 0, 1)).getUTCDay()) /
+				7
+		)
+	}));
+</script>
+
+<div class="year">
+	<header>
+		<div class="headline">
+			<span class="big" data-preserve-case>{YEAR}</span>
+			<span class="sub lab-mono">day {elapsed} of {cells.length} · {percent}% gone</span>
+		</div>
+		<div class="legend lab-mono">
+			<span>quiet</span>
+			{#each [0, 1, 2, 3, 4] as level (level)}
+				<span class="swatch" data-level={level}></span>
+			{/each}
+			<span>busy</span>
+		</div>
+	</header>
+
+	<div class="bar" aria-hidden="true">
+		<span class="bar-fill" style={`width:${percent}%`}></span>
+	</div>
+
+	<div class="scroller">
+		<div class="months lab-mono" aria-hidden="true">
+			{#each months as month (month.name)}
+				<span style={`grid-column:${month.week + 1}`}>{month.name}</span>
+			{/each}
+		</div>
+
+		<div class="grid" role="img" aria-label={`Calendar heatmap for ${YEAR}`}>
+			{#each cells as cell (cell.iso)}
+				<button
+					class="cell"
+					class:future={cell.future}
+					class:today={cell.today}
+					class:marked={!!cell.event}
+					type="button"
+					data-level={cell.level}
+					style={`grid-column:${cell.week + 1}; grid-row:${cell.weekday + 1}`}
+					onmouseenter={() => (hovered = cell)}
+					onfocus={() => (hovered = cell)}
+					onmouseleave={() => (hovered = null)}
+					onblur={() => (hovered = null)}
+					aria-label={`${cell.label}${cell.event ? ` — ${cell.event}` : ''}`}
+				></button>
+			{/each}
+		</div>
+	</div>
+
+	<div class="readout" aria-live="polite">
+		{#if hovered}
+			<span class="readout-date lab-mono">{hovered.label}</span>
+			{#if hovered.event}
+				<span class="readout-event" data-preserve-case>{hovered.event}</span>
+			{:else if hovered.future}
+				<span class="readout-event dim">not yet</span>
+			{:else}
+				<span class="readout-event dim">nothing logged</span>
+			{/if}
+		{:else}
+			<span class="readout-date lab-mono">
+				{events.size} logged moments · hover a day
+			</span>
+		{/if}
+	</div>
+</div>
+
+<style lang="scss">
+	.year {
+		display: grid;
+		gap: 0.85rem;
+	}
+
+	header {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: flex-end;
+		justify-content: space-between;
+		gap: 0.75rem;
+	}
+
+	.headline {
+		display: flex;
+		align-items: baseline;
+		gap: 0.65rem;
+	}
+
+	.big {
+		font-family: var(--lab-kinetic);
+		font-size: clamp(1.9rem, 4vw, 2.8rem);
+		line-height: 1;
+		letter-spacing: -0.03em;
+		color: var(--color-heading);
+		font-variation-settings:
+			'wght' 620,
+			'opsz' 120,
+			'SOFT' 40;
+	}
+
+	.sub {
+		font-size: 0.6rem;
+		color: var(--color-subtle);
+	}
+
+	.legend {
+		display: flex;
+		align-items: center;
+		gap: 0.3rem;
+		font-size: 0.55rem;
+		color: var(--color-subtle);
+	}
+
+	.swatch,
+	.cell {
+		width: 11px;
+		height: 11px;
+		border-radius: 2.5px;
+		border: none;
+		padding: 0;
+	}
+
+	// Shared intensity ramp for both the legend and the grid.
+	.swatch[data-level='0'],
+	.cell[data-level='0'] {
+		background: color-mix(in srgb, var(--color-ink) 8%, transparent);
+	}
+	.swatch[data-level='1'],
+	.cell[data-level='1'] {
+		background: color-mix(in srgb, var(--lab-accent) 25%, transparent);
+	}
+	.swatch[data-level='2'],
+	.cell[data-level='2'] {
+		background: color-mix(in srgb, var(--lab-accent) 45%, transparent);
+	}
+	.swatch[data-level='3'],
+	.cell[data-level='3'] {
+		background: color-mix(in srgb, var(--lab-accent) 70%, transparent);
+	}
+	.swatch[data-level='4'],
+	.cell[data-level='4'] {
+		background: var(--lab-accent);
+	}
+
+	.bar {
+		height: 3px;
+		border-radius: 999px;
+		background: var(--lab-hairline);
+		overflow: hidden;
+	}
+
+	.bar-fill {
+		display: block;
+		height: 100%;
+		border-radius: 999px;
+		background: var(--lab-accent);
+		transition: width 600ms cubic-bezier(0.2, 0.9, 0.3, 1);
+	}
+
+	.scroller {
+		overflow-x: auto;
+		padding-bottom: 0.35rem;
+		scrollbar-width: thin;
+	}
+
+	.months {
+		display: grid;
+		grid-template-columns: repeat(53, 13px);
+		margin-bottom: 0.3rem;
+		font-size: 0.52rem;
+		color: var(--color-subtle);
+	}
+
+	.grid {
+		display: grid;
+		grid-template-columns: repeat(53, 13px);
+		grid-template-rows: repeat(7, 13px);
+		grid-auto-flow: column;
+	}
+
+	.cell {
+		cursor: pointer;
+		transition:
+			transform 120ms ease,
+			outline-color 120ms ease;
+		outline: 1.5px solid transparent;
+		outline-offset: 1px;
+	}
+
+	.cell:hover,
+	.cell:focus-visible {
+		transform: scale(1.45);
+		outline-color: var(--color-heading);
+	}
+
+	.cell.future {
+		background: repeating-linear-gradient(
+			45deg,
+			color-mix(in srgb, var(--color-ink) 6%, transparent) 0 2px,
+			transparent 2px 4px
+		);
+	}
+
+	// Days that carry a real log entry get a ring so they read as landmarks.
+	.cell.marked {
+		background: var(--lab-accent);
+		box-shadow:
+			0 0 0 1.5px var(--color-surface),
+			0 0 0 3px var(--lab-accent);
+	}
+
+	.cell.today {
+		background: var(--color-heading);
+		animation: beat 2.4s ease-in-out infinite;
+	}
+
+	@keyframes beat {
+		0%,
+		100% {
+			box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-heading) 45%, transparent);
+		}
+		50% {
+			box-shadow: 0 0 0 5px transparent;
+		}
+	}
+
+	.readout {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: baseline;
+		gap: 0.6rem;
+		min-height: 1.4rem;
+		padding-top: 0.15rem;
+		border-top: 1px solid var(--lab-hairline);
+		margin-top: 0.2rem;
+	}
+
+	.readout-date {
+		font-size: 0.58rem;
+		color: var(--color-subtle);
+	}
+
+	.readout-event {
+		font-family: var(--font-ui);
+		font-size: 0.88rem;
+		font-weight: 600;
+		color: var(--lab-accent);
+	}
+
+	.readout-event.dim {
+		font-weight: 400;
+		color: var(--color-subtle);
+		opacity: 0.65;
+	}
+</style>

--- a/personal-website/src/routes/lab/lab.scss
+++ b/personal-website/src/routes/lab/lab.scss
@@ -1,0 +1,102 @@
+// ---------------------------------------------------------------------------
+// TEMPORARY — design concept sandbox styles.
+//
+// Scoped to `.lab` so nothing here can leak into the real site. Delete this
+// file together with `src/routes/lab/` when the concepts have been picked over.
+// ---------------------------------------------------------------------------
+
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght,SOFT,WONK@0,9..144,100..900,0..100,0..1;1,9..144,100..900,0..100,0..1&display=swap');
+
+.lab {
+	--lab-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', monospace;
+	--lab-kinetic: 'Fraunces', 'Iowan Old Style', Georgia, serif;
+
+	// Concept demos want more room than the 880px reading measure the rest of
+	// the site uses, so the page-width token is widened for this subtree only.
+	--size-page: min(1180px, calc(100vw - clamp(1.5rem, 5vw, 3rem)));
+
+	--lab-rail: 232px;
+	--lab-panel: color-mix(in srgb, var(--color-surface) 92%, var(--color-muted));
+	--lab-grid-line: color-mix(in srgb, var(--color-ink) 7%, transparent);
+	--lab-hairline: color-mix(in srgb, var(--color-ink) 14%, transparent);
+	--lab-accent: var(--color-green);
+	--lab-accent-soft: color-mix(in srgb, var(--lab-accent) 18%, transparent);
+
+	color: var(--color-ink);
+}
+
+// The global stylesheet centres all body text under 640px. Concept demos are
+// laid out deliberately, so opt the whole sandbox out.
+@media (max-width: 640px) {
+	.lab {
+		text-align: left;
+	}
+}
+
+.lab ::selection {
+	background: var(--lab-accent);
+	color: var(--color-cream);
+}
+
+// --- shared lab chrome ------------------------------------------------------
+
+.lab-mono {
+	font-family: var(--lab-mono);
+	font-size: 0.68rem;
+	font-weight: 500;
+	letter-spacing: 0.14em;
+	text-transform: uppercase;
+}
+
+.lab-chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.28rem 0.6rem;
+	border: 1px solid var(--lab-hairline);
+	border-radius: 999px;
+	font-family: var(--lab-mono);
+	font-size: 0.62rem;
+	font-weight: 500;
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: var(--color-subtle);
+	white-space: nowrap;
+}
+
+.lab-chip[data-tone='accent'] {
+	border-color: color-mix(in srgb, var(--lab-accent) 45%, transparent);
+	background: var(--lab-accent-soft);
+	color: color-mix(in srgb, var(--lab-accent) 78%, var(--color-heading));
+}
+
+// Dotted engineering-paper backdrop used behind live demos.
+.lab-grid-bg {
+	background-image:
+		linear-gradient(var(--lab-grid-line) 1px, transparent 1px),
+		linear-gradient(90deg, var(--lab-grid-line) 1px, transparent 1px);
+	background-size: 28px 28px;
+	background-position: -1px -1px;
+}
+
+// Fine film grain. Kept as a data URI so the sandbox stays self-contained.
+.lab-grain::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	opacity: 0.32;
+	mix-blend-mode: soft-light;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)' opacity='0.55'/%3E%3C/svg%3E");
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.lab *,
+	.lab *::before,
+	.lab *::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+	}
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
       '@humanspeak/svelte-markdown':
         specifier: ^0.8.17
         version: 0.8.17(svelte@5.55.9(@typescript-eslint/types@8.60.0))
+      matter-js:
+        specifier: ^0.20.0
+        version: 0.20.0
     devDependencies:
       '@eslint/compat':
         specifier: ^1.4.1
@@ -123,6 +126,9 @@ importers:
       '@sveltejs/vite-plugin-svelte':
         specifier: ^7.0.0
         version: 7.1.2(svelte@5.55.9(@typescript-eslint/types@8.60.0))(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(sass@1.100.0)(tsx@4.22.3))
+      '@types/matter-js':
+        specifier: ^0.20.2
+        version: 0.20.2
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
@@ -1098,6 +1104,9 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/matter-js@0.20.2':
+    resolution: {integrity: sha512-3PPKy3QxvZ89h9+wdBV2488I1JLVs7DEpIkPvgO8JC1mUdiVSO37ZIvVctOTD7hIq8OAL2gJ3ugGSuUip6DhCw==}
+
   '@types/node@25.9.1':
     resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
@@ -1653,6 +1662,9 @@ packages:
     resolution: {integrity: sha512-gB0gkNafnonOw0obSTEGZTT86IuhILt2Wfx0mWH/1Au83kybTayroZ/V6nS25mN7u8ASy+5fMhgB3XPNrOZdmA==}
     engines: {node: '>= 20'}
     hasBin: true
+
+  matter-js@0.20.0:
+    resolution: {integrity: sha512-iC9fYR7zVT3HppNnsFsp9XOoQdQN2tUyfaKg4CHLH8bN+j6GT4Gw7IH2rP0tflAebrHFw730RR3DkVSZRX8hwA==}
 
   mdn-data@2.0.28:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
@@ -2712,6 +2724,8 @@ snapshots:
 
   '@types/json-schema@7.0.15': {}
 
+  '@types/matter-js@0.20.2': {}
+
   '@types/node@25.9.1':
     dependencies:
       undici-types: 7.24.6
@@ -3366,6 +3380,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   marked@17.0.6: {}
+
+  matter-js@0.20.0: {}
 
   mdn-data@2.0.28: {}
 


### PR DESCRIPTION
A disposable sandbox at **`/lab`** holding 22 self-contained, live design concepts for the site, so they can be judged in the browser rather than as mockups — then kept or binned individually.

Nothing here is wired into the real pages. Everything lives under `personal-website/src/routes/lab/`, which is the only thing that needs deleting to remove the page. The route is `noindex, nofollow`, and nothing outside the folder imports from it.

## What's in it

Each concept is one component under `lab/concepts/`, with a note on where it would live on the real site.

| # | Concept | Would sit in |
|---|---|---|
| 01 | Kinetic masthead — per-glyph variable-font response to the cursor | home hero |
| 02 | Aurora hero — drifting canvas colour field + grain | home hero |
| 03 | Command palette — ⌘K fuzzy index over the whole site | site-wide |
| 04 | Counting stats with data-derived sparklines | about / home |
| 05 | Spotlight grid — shared cursor torch, proximity-lit borders | home index |
| 06 | Velocity ticker — speed/skew/weight driven by scroll velocity | section divider |
| 07 | Three text treatments — decode, marker highlight, focus pull | headings |
| 08 | Elastic segmented nav — spring-driven indicator with squash | filters / nav |
| 09 | Hover-preview index — cover trails the cursor, rows recede | book notes index |
| 10 | 3D bookshelf — real spines in CSS 3D, drag to pan | book notes |
| 11 | Film contact sheet — sweep a frame to scrub the roll | photography index |
| 12 | Throwable photo deck | photography |
| 13 | Pinned horizontal story — five panels of process | about / process |
| 14 | Scroll-driven log — native `animation-timeline`, with fallback | 2026 page |
| 15 | The year in days — 365-cell heatmap with logged moments | 2026 page |
| 16 | Live status card — Melbourne clock + real sunrise/sunset arc | home / about |
| 17 | Interest constellation — force-directed map | about / colophon |
| 18 | Physics tag pile — matter-js rigid bodies | about |
| 19 | Marginalia reader — margin notes, footnotes, focus mode | writing |
| 20 | Reaction bar — tap to react, hold for confetti | writing / photos |
| 21 | Theme studio — four sliders generate a live oklch palette | footer / easter egg |
| 22 | Mega wordmark footer — photo-filled name, clipped and rising | footer |

## Notes on the implementation

- Concepts read from the existing content modules, so they show real books, trips and log entries rather than placeholder data.
- Shared metadata in `+page.svelte` feeds the index rail, the section headers and the numbering from a single list, so nothing drifts as concepts are cut.
- Existing tokens, dark theme and lowercase mode are respected throughout; every rAF loop, canvas and the physics solver pauses off-screen and under `prefers-reduced-motion`.
- Time- and randomness-dependent concepts (clock, year grid, sparklines) render deterministically on the server and resolve on mount, so hydration never mismatches.
- `matter-js` is the only third-party dependency, used by concept 18 and imported dynamically on the client. If that concept goes, so does the dependency.

## Checks

- `pnpm --filter @matejgroombridge/personal-website check` — no new errors or warnings from these files. The 12 pre-existing errors in `src/routes/writing/[slug]/` are untouched by this branch.
- `pnpm exec eslint src/routes/lab` — clean.
- `pnpm build:new` — passes; all 22 concepts server-render.
- Driven in Chromium at 1440px and 390px: no page errors, and zero horizontal overflow at either width.

---
_Generated by [Claude Code](https://claude.ai/code/session_014AFm4bid4FUdfGURwRSTFq)_